### PR TITLE
fix(scripts): remove last crowdfunding-types reference from dev.sh

### DIFF
--- a/scripts/development/dev.sh
+++ b/scripts/development/dev.sh
@@ -149,7 +149,7 @@ build_packages() {
     echo -e "${GREEN}📦 Building packages...${NC}"
     
     # Build in dependency order
-    local packages=("types" "utils" "ui" "auth-client" "auth-context" "crowdfunding-types" "forum-types" "shortcodes")
+    local packages=("types" "utils" "ui" "auth-client" "auth-context" "forum-types" "shortcodes")
     
     for pkg in "${packages[@]}"; do
         if [ -d "packages/$pkg" ]; then


### PR DESCRIPTION
## Summary
- `build_packages()` 함수에 남아있던 `crowdfunding-types` 참조를 제거합니다
- 기존 커밋 `d938f1b2e`에서 누락된 1건의 정리입니다
- WO-MARKET-TRIAL-CROWDFUNDING-DEAD-CODE-CLEANUP-V1 완료

## Test plan
- [x] `pnpm build` 전체 통과 확인
- [x] `grep -r crowdfunding` 잔여 참조 확인 (archive/ 주석만 남음)
- [x] MarketTrial 운영 코드 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)