### PR TITLE
feat(market-trial): add participation request UI to Trial detail page

### DIFF
--- a/services/web-kpa-society/src/api/marketTrial.ts
+++ b/services/web-kpa-society/src/api/marketTrial.ts
@@ -108,3 +108,51 @@ export async function getTrialDetail(id: string): Promise<{ success: boolean; da
   });
   return res.json();
 }
+
+// ── Participation ──
+
+export interface ParticipationInfo {
+  id: string;
+  trialId: string;
+  participantId: string;
+  role: string;
+  rewardType: 'cash' | 'product';
+  rewardStatus: 'pending' | 'fulfilled';
+  joinedAt: string;
+}
+
+/**
+ * 현재 사용자의 참여 정보 조회
+ * WO-MARKET-TRIAL-PARTICIPATION-REQUEST-UI-V1
+ */
+export async function getParticipation(
+  trialId: string,
+): Promise<{ success: boolean; data: ParticipationInfo | null }> {
+  const token = getAccessToken();
+  if (!token) return { success: true, data: null };
+  const res = await fetch(`${API_BASE}/api/market-trial/${trialId}/participation`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.json();
+}
+
+/**
+ * Trial 참여 신청
+ * WO-MARKET-TRIAL-PARTICIPATION-REQUEST-UI-V1
+ */
+export async function joinTrial(
+  trialId: string,
+  rewardType: 'cash' | 'product',
+): Promise<{ success: boolean; data?: ParticipationInfo; message?: string }> {
+  const token = getAccessToken();
+  if (!token) return { success: false, message: '로그인이 필요합니다.' };
+  const res = await fetch(`${API_BASE}/api/market-trial/${trialId}/join`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ rewardType }),
+  });
+  return res.json();
+}

--- a/services/web-kpa-society/src/pages/market-trial/MarketTrialDetailPage.tsx
+++ b/services/web-kpa-society/src/pages/market-trial/MarketTrialDetailPage.tsx
@@ -2,18 +2,24 @@
  * MarketTrialDetailPage - 시범판매 개별 상세
  *
  * WO-MARKET-TRIAL-KPA-DETAIL-AND-FORUM-DEEP-LINK-V1
+ * WO-MARKET-TRIAL-PARTICIPATION-REQUEST-UI-V1
  *
  * 역할:
  * - Trial 운영 정보 요약 (제목, 상태, 공급자, 참여 목적, 대상, 보상, 일정, 참여현황)
+ * - 참여 신청 UI (모집중 상태일 때 보상 선택 + 신청 버튼)
  * - 해당 Trial에 연결된 포럼 게시글로 직접 이동 (deep link)
  * - 허브(/market-trial)로 복귀
- *
- * 포럼을 대체하지 않고, 포럼으로 가기 전 trial 이해를 돕는 운영 요약 화면.
  */
 
 import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { getTrialDetail, type TrialSummary } from '../../api/marketTrial';
+import {
+  getTrialDetail,
+  getParticipation,
+  joinTrial,
+  type TrialSummary,
+  type ParticipationInfo,
+} from '../../api/marketTrial';
 import { colors, borderRadius } from '../../styles/theme';
 
 // ── 상태 라벨 ──
@@ -43,15 +49,32 @@ export function MarketTrialDetailPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // ── 참여 상태 ──
+  const [participation, setParticipation] = useState<ParticipationInfo | null>(null);
+  const [selectedReward, setSelectedReward] = useState<'cash' | 'product' | null>(null);
+  const [joinLoading, setJoinLoading] = useState(false);
+  const [joinError, setJoinError] = useState<string | null>(null);
+  const [joinSuccess, setJoinSuccess] = useState(false);
+
   useEffect(() => {
     if (!id) return;
-    const fetchTrial = async () => {
+    const fetchData = async () => {
       try {
-        const response = await getTrialDetail(id);
-        if (response.success) {
-          setTrial(response.data);
+        const [trialRes, partRes] = await Promise.all([
+          getTrialDetail(id),
+          getParticipation(id),
+        ]);
+        if (trialRes.success) {
+          setTrial(trialRes.data);
+          // 기본 보상 선택: rewardOptions가 하나뿐이면 자동 선택
+          if (trialRes.data.rewardOptions?.length === 1) {
+            setSelectedReward(trialRes.data.rewardOptions[0] as 'cash' | 'product');
+          }
         } else {
           setError('시범판매를 찾을 수 없습니다.');
+        }
+        if (partRes.success && partRes.data) {
+          setParticipation(partRes.data);
         }
       } catch {
         setError('정보를 불러오는 중 오류가 발생했습니다.');
@@ -59,8 +82,47 @@ export function MarketTrialDetailPage() {
         setIsLoading(false);
       }
     };
-    fetchTrial();
+    fetchData();
   }, [id]);
+
+  // ── 참여 신청 핸들러 ──
+  const handleJoin = async () => {
+    if (!id || !selectedReward || joinLoading) return;
+    setJoinLoading(true);
+    setJoinError(null);
+
+    try {
+      const res = await joinTrial(id, selectedReward);
+      if (res.success && res.data) {
+        setParticipation(res.data);
+        setJoinSuccess(true);
+        // 참여자 수 즉시 반영
+        if (trial) {
+          setTrial({ ...trial, currentParticipants: trial.currentParticipants + 1 });
+        }
+      } else {
+        // 서버 에러 메시지 → 사용자 친화적 변환
+        const msg = res.message || '참여 신청에 실패했습니다.';
+        if (msg.includes('Already participated')) {
+          setJoinError('이미 참여 신청한 시범판매입니다.');
+        } else if (msg.includes('not accepting')) {
+          setJoinError('현재 참여 신청을 받고 있지 않습니다.');
+        } else if (msg.includes('maximum participants')) {
+          setJoinError('참여 정원이 마감되었습니다.');
+        } else if (msg.includes('Authentication')) {
+          setJoinError('로그인이 필요합니다. 다시 로그인 후 시도해 주세요.');
+        } else if (msg.includes('not available')) {
+          setJoinError('선택한 보상 방식을 사용할 수 없습니다.');
+        } else {
+          setJoinError(msg);
+        }
+      }
+    } catch {
+      setJoinError('네트워크 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      setJoinLoading(false);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -90,6 +152,10 @@ export function MarketTrialDetailPage() {
   const rewardLabels = (trial.rewardOptions || [])
     .map((r) => REWARD_LABELS[r] || r)
     .filter(Boolean);
+
+  const isRecruiting = trial.status === 'recruiting';
+  const isFull = trial.maxParticipants != null && trial.currentParticipants >= trial.maxParticipants;
+  const hasJoined = participation != null || joinSuccess;
 
   return (
     <div style={{ maxWidth: '760px', margin: '0 auto', padding: '32px 16px 64px' }}>
@@ -223,6 +289,147 @@ export function MarketTrialDetailPage() {
         </div>
       </section>
 
+      {/* ── 참여 신청 섹션 ── */}
+      <section style={{
+        backgroundColor: colors.white,
+        borderRadius: borderRadius.lg,
+        border: `1px solid ${hasJoined ? '#BBF7D0' : colors.neutral200}`,
+        padding: '20px 24px',
+        marginBottom: '20px',
+      }}>
+        <h3 style={{ fontSize: '0.875rem', fontWeight: 600, color: colors.neutral700, marginBottom: '12px' }}>
+          참여 신청
+        </h3>
+
+        {/* A. 이미 참여함 */}
+        {hasJoined && (
+          <div>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              padding: '12px 16px',
+              backgroundColor: '#F0FDF4',
+              borderRadius: borderRadius.md,
+              marginBottom: '12px',
+            }}>
+              <span style={{ fontSize: '1.125rem', color: '#166534' }}>&#10003;</span>
+              <div>
+                <p style={{ fontSize: '0.875rem', fontWeight: 600, color: '#166534', margin: 0 }}>
+                  참여 신청 완료
+                </p>
+                <p style={{ fontSize: '0.8125rem', color: '#15803D', margin: '2px 0 0 0' }}>
+                  보상 방식: {REWARD_LABELS[participation?.rewardType || selectedReward || ''] || '선택됨'}
+                </p>
+              </div>
+            </div>
+            {joinSuccess && (
+              <p style={{ fontSize: '0.8125rem', color: colors.neutral500, lineHeight: 1.5, margin: 0 }}>
+                참여 신청이 완료되었습니다. 포럼에서 다른 참여자들과 의견을 나눌 수 있습니다.
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* B. 모집중 — 신청 가능 */}
+        {!hasJoined && isRecruiting && !isFull && (
+          <div>
+            <p style={{ fontSize: '0.8125rem', color: colors.neutral500, lineHeight: 1.5, marginBottom: '14px' }}>
+              이 시범판매에 참여하시겠습니까? 보상 방식을 선택한 후 신청해 주세요.
+            </p>
+
+            {/* 보상 선택 */}
+            {trial.rewardOptions.length > 1 && (
+              <div style={{ display: 'flex', gap: '8px', marginBottom: '14px' }}>
+                {trial.rewardOptions.map((opt) => {
+                  const isSelected = selectedReward === opt;
+                  return (
+                    <button
+                      key={opt}
+                      onClick={() => setSelectedReward(opt as 'cash' | 'product')}
+                      style={{
+                        flex: 1,
+                        padding: '10px 12px',
+                        border: `2px solid ${isSelected ? colors.primary : colors.neutral200}`,
+                        borderRadius: borderRadius.md,
+                        backgroundColor: isSelected ? `${colors.primary}0D` : colors.white,
+                        color: isSelected ? colors.primary : colors.neutral600,
+                        fontSize: '0.8125rem',
+                        fontWeight: isSelected ? 600 : 400,
+                        cursor: 'pointer',
+                        transition: 'all 0.15s',
+                      }}
+                    >
+                      {REWARD_LABELS[opt] || opt}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* 에러 메시지 */}
+            {joinError && (
+              <p style={{
+                fontSize: '0.8125rem',
+                color: '#DC2626',
+                backgroundColor: '#FEF2F2',
+                padding: '8px 12px',
+                borderRadius: borderRadius.md,
+                marginBottom: '12px',
+              }}>
+                {joinError}
+              </p>
+            )}
+
+            {/* 신청 버튼 */}
+            <button
+              onClick={handleJoin}
+              disabled={!selectedReward || joinLoading}
+              style={{
+                width: '100%',
+                padding: '12px 20px',
+                backgroundColor: !selectedReward || joinLoading ? colors.neutral300 : '#16A34A',
+                color: colors.white,
+                borderRadius: borderRadius.md,
+                fontSize: '0.875rem',
+                fontWeight: 600,
+                border: 'none',
+                cursor: !selectedReward || joinLoading ? 'not-allowed' : 'pointer',
+                transition: 'background-color 0.15s',
+              }}
+            >
+              {joinLoading ? '신청 중...' : selectedReward ? '시범판매 참여 신청' : '보상 방식을 선택해 주세요'}
+            </button>
+          </div>
+        )}
+
+        {/* C. 정원 마감 */}
+        {!hasJoined && isRecruiting && isFull && (
+          <div style={{
+            padding: '12px 16px',
+            backgroundColor: '#FEF3C7',
+            borderRadius: borderRadius.md,
+          }}>
+            <p style={{ fontSize: '0.875rem', fontWeight: 500, color: '#92400E', margin: 0 }}>
+              참여 정원이 마감되었습니다. ({trial.currentParticipants} / {trial.maxParticipants}명)
+            </p>
+          </div>
+        )}
+
+        {/* D. 모집중이 아님 */}
+        {!hasJoined && !isRecruiting && (
+          <div style={{
+            padding: '12px 16px',
+            backgroundColor: colors.neutral50,
+            borderRadius: borderRadius.md,
+          }}>
+            <p style={{ fontSize: '0.875rem', color: colors.neutral500, margin: 0 }}>
+              현재는 참여 신청을 받고 있지 않습니다. (상태: {statusInfo.label})
+            </p>
+          </div>
+        )}
+      </section>
+
       {/* ── 포럼 연결 ── */}
       <section style={{
         backgroundColor: colors.white,
@@ -253,7 +460,7 @@ export function MarketTrialDetailPage() {
                 textDecoration: 'none',
               }}
             >
-              포럼 게시글 바로가기 →
+              포럼에서 의견 보기 →
             </Link>
           </>
         ) : (


### PR DESCRIPTION
## Summary
- **WO-MARKET-TRIAL-PARTICIPATION-REQUEST-UI-V1**
- Trial 상세 페이지에 참여 신청 UI 추가
- `getParticipation()`, `joinTrial()` API 클라이언트 함수 추가
- 4-state UI 분기 구현: 이미 참여함, 모집중(신청 가능), 정원 마감, 모집중 아님
- 보상 방식 선택기 (cash/product), 단일 옵션 자동 선택
- 참여자 수 Optimistic update, 서버 에러 메시지 한국어 변환

## Changed Files
| File | Change |
|------|--------|
| `services/web-kpa-society/src/api/marketTrial.ts` | `ParticipationInfo` 인터페이스, `getParticipation()`, `joinTrial()` 추가 |
| `services/web-kpa-society/src/pages/market-trial/MarketTrialDetailPage.tsx` | 참여 신청 섹션 + 4-state UI 분기 구현 |

## Test plan
- [ ] `/market-trial/:id` 접속 — 참여 신청 섹션 노출 확인
- [ ] 모집중 Trial: 보상 선택 → 신청 버튼 → 성공 메시지
- [ ] 이미 참여한 Trial: 초록색 완료 뱃지
- [ ] 정원 마감 Trial: 노란색 마감 안내
- [ ] 모집중이 아닌 Trial: 회색 안내 메시지
- [ ] 빌드 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)