### PR TITLE
feat(market-trial): add my participation status to Hub and Detail

### DIFF
--- a/apps/api-server/src/controllers/market-trial/marketTrialController.ts
+++ b/apps/api-server/src/controllers/market-trial/marketTrialController.ts
@@ -10,6 +10,9 @@
  *
  * WO-MARKET-TRIAL-KPA-DETAIL-AND-FORUM-DEEP-LINK-V1:
  * getTrials/getTrialById에 forumPostId 포함하여 개별 포럼 deep link 지원
+ *
+ * WO-MARKET-TRIAL-MY-PARTICIPATION-STATUS-V1:
+ * getMyParticipations() — 현재 사용자의 전체 참여 목록 반환 (허브 참여 상태 표시용)
  */
 
 import { Response } from 'express';
@@ -215,6 +218,56 @@ export class MarketTrialController {
     } catch (error) {
       console.error('Get my trials error:', error);
       res.status(500).json({ success: false, message: 'Failed to get trials' });
+    }
+  }
+
+  /**
+   * GET /api/market-trial/my-participations
+   * 현재 사용자가 참여한 Trial 목록 (참여 상태 + Trial 요약 포함)
+   * WO-MARKET-TRIAL-MY-PARTICIPATION-STATUS-V1
+   */
+  static async getMyParticipations(req: AuthRequest, res: Response) {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) {
+        return res.status(401).json({ success: false, message: 'Authentication required' });
+      }
+
+      const participations = await MarketTrialController.participantRepo.find({
+        where: { participantId: userId },
+        order: { createdAt: 'DESC' },
+      });
+
+      if (participations.length === 0) {
+        return res.json({ success: true, data: [] });
+      }
+
+      // Batch-fetch trial data for all participations
+      const trialIds = participations.map((p) => p.marketTrialId);
+      const trials = await MarketTrialController.trialRepo
+        .createQueryBuilder('trial')
+        .where('trial.id IN (:...ids)', { ids: trialIds })
+        .getMany();
+
+      const trialMap = new Map(trials.map((t) => [t.id, t]));
+
+      const data = participations.map((p) => {
+        const trial = trialMap.get(p.marketTrialId);
+        return {
+          ...toParticipationDTO(p),
+          trial: trial ? {
+            id: trial.id,
+            title: trial.title,
+            status: trial.status,
+            supplierName: trial.supplierName || undefined,
+          } : undefined,
+        };
+      });
+
+      res.json({ success: true, data });
+    } catch (error) {
+      console.error('Get my participations error:', error);
+      res.status(500).json({ success: false, message: 'Failed to get participations' });
     }
   }
 

--- a/apps/api-server/src/routes/market-trial.routes.ts
+++ b/apps/api-server/src/routes/market-trial.routes.ts
@@ -17,6 +17,9 @@ const router: Router = Router();
 router.post('/', authenticate, MarketTrialController.createTrial);
 router.get('/my', authenticate, MarketTrialController.getMyTrials);
 
+// User participations (WO-MARKET-TRIAL-MY-PARTICIPATION-STATUS-V1)
+router.get('/my-participations', authenticate, MarketTrialController.getMyParticipations);
+
 // Gateway: access status + open trial summary (WO-MARKET-TRIAL-SERVICE-ENTRY-BANNER-AND-GATEWAY-V1)
 router.get('/gateway', optionalAuth, MarketTrialController.gateway);
 

--- a/services/web-kpa-society/src/api/marketTrial.ts
+++ b/services/web-kpa-society/src/api/marketTrial.ts
@@ -4,6 +4,7 @@
  * WO-MARKET-TRIAL-SERVICE-ENTRY-BANNER-AND-GATEWAY-V1
  * WO-MARKET-TRIAL-KPA-TRIAL-HUB-REFINE-V1
  * WO-MARKET-TRIAL-KPA-DETAIL-AND-FORUM-DEEP-LINK-V1
+ * WO-MARKET-TRIAL-MY-PARTICIPATION-STATUS-V1
  *
  * Market Trial API는 /api/market-trial에 마운트되어 있어
  * KPA apiClient(/api/v1/kpa prefix)와 호환되지 않음.
@@ -153,6 +154,33 @@ export async function joinTrial(
       Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({ rewardType }),
+  });
+  return res.json();
+}
+
+// ── My Participations ──
+
+export interface MyParticipationSummary extends ParticipationInfo {
+  trial?: {
+    id: string;
+    title: string;
+    status: string;
+    supplierName?: string;
+  };
+}
+
+/**
+ * 현재 사용자의 전체 참여 목록 조회
+ * WO-MARKET-TRIAL-MY-PARTICIPATION-STATUS-V1
+ */
+export async function getMyParticipations(): Promise<{
+  success: boolean;
+  data: MyParticipationSummary[];
+}> {
+  const token = getAccessToken();
+  if (!token) return { success: true, data: [] };
+  const res = await fetch(`${API_BASE}/api/market-trial/my-participations`, {
+    headers: { Authorization: `Bearer ${token}` },
   });
   return res.json();
 }

--- a/services/web-kpa-society/src/pages/market-trial/MarketTrialDetailPage.tsx
+++ b/services/web-kpa-society/src/pages/market-trial/MarketTrialDetailPage.tsx
@@ -320,6 +320,9 @@ export function MarketTrialDetailPage() {
                 </p>
                 <p style={{ fontSize: '0.8125rem', color: '#15803D', margin: '2px 0 0 0' }}>
                   보상 방식: {REWARD_LABELS[participation?.rewardType || selectedReward || ''] || '선택됨'}
+                  {participation?.joinedAt && (
+                    <> · 참여일: {new Date(participation.joinedAt).toLocaleDateString()}</>
+                  )}
                 </p>
               </div>
             </div>

--- a/services/web-kpa-society/src/pages/market-trial/MarketTrialHubPage.tsx
+++ b/services/web-kpa-society/src/pages/market-trial/MarketTrialHubPage.tsx
@@ -4,18 +4,25 @@
  * WO-MARKET-TRIAL-SERVICE-ENTRY-BANNER-AND-GATEWAY-V1: 초기 구현
  * WO-MARKET-TRIAL-KPA-TRIAL-HUB-REFINE-V1: 운영형 허브로 정비
  * WO-MARKET-TRIAL-KPA-DETAIL-AND-FORUM-DEEP-LINK-V1: 상세/포럼 액션 분리
+ * WO-MARKET-TRIAL-MY-PARTICIPATION-STATUS-V1: 내 참여 상태 표시
  *
  * 구조:
  * 1. 헤더 + 허브 설명
  * 2. 참여 안내 (3단 흐름)
- * 3. 모집 중 Trial 섹션 (주요)
- * 4. 진행 중 / 종료 Trial 섹션 (보조)
- * 5. 포럼 연결 안내
+ * 3. 내가 참여한 시범판매 섹션 (로그인 시)
+ * 4. 모집 중 Trial 섹션 (주요)
+ * 5. 진행 중 / 종료 Trial 섹션 (보조)
+ * 6. 포럼 연결 안내
  */
 
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { getTrials, type TrialSummary } from '../../api/marketTrial';
+import {
+  getTrials,
+  getMyParticipations,
+  type TrialSummary,
+  type ParticipationInfo,
+} from '../../api/marketTrial';
 import { colors, borderRadius } from '../../styles/theme';
 
 // ── 상태 분류 ──
@@ -45,16 +52,33 @@ const SERVICE_KEY_LABELS: Record<string, string> = {
 
 // ── 메인 컴포넌트 ──
 
+const REWARD_LABELS: Record<string, string> = {
+  product: '제품 보상',
+  cash: '현금 보상',
+};
+
 export function MarketTrialHubPage() {
   const [trials, setTrials] = useState<TrialSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  // 내 참여 상태 (trialId → ParticipationInfo)
+  const [participationMap, setParticipationMap] = useState<Map<string, ParticipationInfo>>(new Map());
 
   useEffect(() => {
-    const fetchTrials = async () => {
+    const fetchData = async () => {
       try {
-        const response = await getTrials();
-        if (response.success) {
-          setTrials(response.data);
+        const [trialsRes, partRes] = await Promise.all([
+          getTrials(),
+          getMyParticipations().catch(() => ({ success: true as const, data: [] })),
+        ]);
+        if (trialsRes.success) {
+          setTrials(trialsRes.data);
+        }
+        if (partRes.success && partRes.data.length > 0) {
+          const map = new Map<string, ParticipationInfo>();
+          for (const p of partRes.data) {
+            map.set(p.trialId, p);
+          }
+          setParticipationMap(map);
         }
       } catch {
         setTrials([]);
@@ -62,12 +86,15 @@ export function MarketTrialHubPage() {
         setIsLoading(false);
       }
     };
-    fetchTrials();
+    fetchData();
   }, []);
 
   const recruiting = trials.filter((t) => getDisplayGroup(t.status) === 'recruiting');
   const active = trials.filter((t) => getDisplayGroup(t.status) === 'active');
   const ended = trials.filter((t) => getDisplayGroup(t.status) === 'ended');
+
+  // 내가 참여한 Trial 목록
+  const myTrials = trials.filter((t) => participationMap.has(t.id));
 
   return (
     <div style={{ maxWidth: '920px', margin: '0 auto', padding: '32px 16px 64px' }}>
@@ -123,7 +150,16 @@ export function MarketTrialHubPage() {
         ))}
       </section>
 
-      {/* ── 3. 모집 중 (Recruiting) ── */}
+      {/* ── 3. 내가 참여한 시범판매 ── */}
+      {myTrials.length > 0 && (
+        <Section title="내가 참여한 시범판매" count={myTrials.length} accentColor="#7C3AED">
+          {myTrials.map((trial) => (
+            <TrialCard key={`my-${trial.id}`} trial={trial} group={getDisplayGroup(trial.status)} participation={participationMap.get(trial.id)} />
+          ))}
+        </Section>
+      )}
+
+      {/* ── 4. 모집 중 (Recruiting) ── */}
       <Section
         title="모집 중"
         count={recruiting.length}
@@ -132,27 +168,27 @@ export function MarketTrialHubPage() {
       >
         {recruiting.length > 0 ? (
           recruiting.map((trial) => (
-            <TrialCard key={trial.id} trial={trial} group="recruiting" />
+            <TrialCard key={trial.id} trial={trial} group="recruiting" participation={participationMap.get(trial.id)} />
           ))
         ) : (
           <EmptySection />
         )}
       </Section>
 
-      {/* ── 4. 진행 중 ── */}
+      {/* ── 5. 진행 중 ── */}
       {active.length > 0 && (
         <Section title="진행 중" count={active.length} accentColor="#2563EB">
           {active.map((trial) => (
-            <TrialCard key={trial.id} trial={trial} group="active" />
+            <TrialCard key={trial.id} trial={trial} group="active" participation={participationMap.get(trial.id)} />
           ))}
         </Section>
       )}
 
-      {/* ── 5. 종료 ── */}
+      {/* ── 6. 종료 ── */}
       {ended.length > 0 && (
         <Section title="종료" count={ended.length} accentColor={colors.neutral400}>
           {ended.map((trial) => (
-            <TrialCard key={trial.id} trial={trial} group="ended" />
+            <TrialCard key={trial.id} trial={trial} group="ended" participation={participationMap.get(trial.id)} />
           ))}
         </Section>
       )}
@@ -258,8 +294,9 @@ function Section({
 
 // ── Trial 카드 ──
 
-function TrialCard({ trial, group }: { trial: TrialSummary; group: DisplayGroup }) {
+function TrialCard({ trial, group, participation }: { trial: TrialSummary; group: DisplayGroup; participation?: ParticipationInfo }) {
   const isEnded = group === 'ended';
+  const hasJoined = !!participation;
 
   const statusBadge = (() => {
     switch (group) {
@@ -280,13 +317,13 @@ function TrialCard({ trial, group }: { trial: TrialSummary; group: DisplayGroup 
     <div style={{
       backgroundColor: colors.white,
       borderRadius: borderRadius.lg,
-      border: `1px solid ${colors.neutral200}`,
+      border: `1px solid ${hasJoined ? '#C4B5FD' : colors.neutral200}`,
       opacity: isEnded ? 0.65 : 1,
       overflow: 'hidden',
     }}>
       {/* 카드 본문 */}
       <div style={{ padding: '20px 24px' }}>
-        {/* 상단: 상태 + 공급자 + 서비스 태그 */}
+        {/* 상단: 상태 + 참여 배지 + 공급자 + 서비스 태그 */}
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px', flexWrap: 'wrap' }}>
           <span style={{
             padding: '2px 10px',
@@ -298,6 +335,18 @@ function TrialCard({ trial, group }: { trial: TrialSummary; group: DisplayGroup 
           }}>
             {statusBadge.label}
           </span>
+          {hasJoined && (
+            <span style={{
+              padding: '2px 10px',
+              backgroundColor: '#EDE9FE',
+              color: '#6D28D9',
+              borderRadius: '12px',
+              fontSize: '0.75rem',
+              fontWeight: 600,
+            }}>
+              내 참여 · {REWARD_LABELS[participation.rewardType] || participation.rewardType}
+            </span>
+          )}
           {trial.supplierName && (
             <span style={{ fontSize: '0.8125rem', color: colors.neutral400 }}>
               {trial.supplierName}


### PR DESCRIPTION
## Summary
- **WO-MARKET-TRIAL-MY-PARTICIPATION-STATUS-V1**
- 허브/상세에서 사용자의 참여 상태를 한눈에 확인할 수 있도록 보강
- Backend: `GET /api/market-trial/my-participations` 엔드포인트 추가
- Hub: "내가 참여한 시범판매" 섹션 + 카드별 "내 참여 · 보상방식" 배지
- Detail: 참여 완료 상태에 참여일(joinedAt) 표시

## Changed Files
| File | Change |
|------|--------|
| `apps/api-server/src/controllers/market-trial/marketTrialController.ts` | `getMyParticipations()` 핸들러 추가 |
| `apps/api-server/src/routes/market-trial.routes.ts` | `GET /my-participations` 라우트 등록 |
| `services/web-kpa-society/src/api/marketTrial.ts` | `MyParticipationSummary`, `getMyParticipations()` 추가 |
| `services/web-kpa-society/src/pages/market-trial/MarketTrialHubPage.tsx` | 내 참여 섹션 + 배지 + 병렬 조회 |
| `services/web-kpa-society/src/pages/market-trial/MarketTrialDetailPage.tsx` | 참여일 표시 보강 |

## Test plan
- [ ] 허브: 내가 참여한 Trial에 보라색 "내 참여" 배지 표시
- [ ] 허브: "내가 참여한 시범판매" 섹션 노출 (참여 Trial 있을 때)
- [ ] 허브: 미참여 Trial과 참여 Trial이 시각적으로 구분됨
- [ ] 상세: 참여 완료 상태에서 보상 방식 + 참여일 표시
- [ ] 미로그인 시 참여 배지/섹션 미노출 (페이지 깨지지 않음)
- [ ] API 실패 시 허브 기본 구조 정상 (graceful fallback)
- [ ] 빌드 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)