### PR TITLE
WO-O4O-HEADER-UNIFICATION-MAIN-APPLY-V1

### DIFF
--- a/packages/account-ui/src/components/GlobalUserProfileDropdown.tsx
+++ b/packages/account-ui/src/components/GlobalUserProfileDropdown.tsx
@@ -1,0 +1,253 @@
+/**
+ * GlobalUserProfileDropdown — Header 사용자 프로필 드롭다운 공통 컴포넌트
+ *
+ * WO-O4O-GLOBAL-USER-PROFILE-DROPDOWN-EXTRACTION-V1
+ *
+ * 4개 서비스(KPA-Society, GlycoPharm, K-Cosmetics, Neture)에 중복 구현된
+ * Header 사용자 영역의 공통 추출. UI/동작만 담당하며, role/serviceKey/auth context
+ * 판단은 모두 호출 측에서 수행한 결과를 props로 받는다.
+ *
+ * 기준 reference: Neture AccountMenu (click trigger, a11y, outside-close, ESC-close)
+ */
+
+import { useState, useRef, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { User, LogOut } from 'lucide-react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface GlobalUserProfileUser {
+  /** 표시 이름 — 호출 측에서 getUserDisplayName 등으로 미리 계산 */
+  displayName: string;
+  /** 이메일 */
+  email?: string | null;
+  /** 역할 라벨 (e.g. "운영자", "공급자") */
+  roleLabel?: string | null;
+  /** 헤더 우측 배지 (e.g. Super Operator) */
+  badge?: ReactNode;
+}
+
+export interface GlobalUserProfileMenuItem {
+  /** 항목 식별 키 */
+  key: string;
+  /** 좌측 아이콘 */
+  icon?: ReactNode;
+  /** 라벨 */
+  label?: ReactNode;
+  /** 내부 라우트 경로 — react-router Link 사용 */
+  href?: string;
+  /** 클릭 핸들러 — href 없을 때 사용 */
+  onClick?: () => void;
+  /** 표시 변형 */
+  variant?: 'default' | 'highlighted';
+  /**
+   * 커스텀 렌더 — KPA DashboardSwitcher 같은 특수 항목을 흡수.
+   * node가 있으면 다른 필드(icon/label/href/onClick)는 무시되고 ReactNode가 그대로 렌더된다.
+   *
+   * 두 가지 형태 지원:
+   *   - `ReactNode` — 정적 노드 (드롭다운 닫힘 처리는 호출 측에서 별도 수행)
+   *   - `(close: () => void) => ReactNode` — close 콜백을 받아 onNavigate 등에 전달 가능
+   */
+  node?: ReactNode | ((close: () => void) => ReactNode);
+}
+
+export interface GlobalUserProfileDropdownProps {
+  user: GlobalUserProfileUser;
+  menuItems: GlobalUserProfileMenuItem[];
+  onLogout: () => void;
+  logoutLabel?: string;
+  /** 트리거 패턴 — 기본 click. KPA 호환을 위해 'hover' 옵션 허용 */
+  trigger?: 'click' | 'hover';
+  /** 패널 정렬 — 기본 'right' */
+  align?: 'right' | 'left';
+  /** 패널 너비 Tailwind 클래스 — 기본 w-64 */
+  widthClassName?: string;
+  /** 추가 wrapper className */
+  className?: string;
+  /** 트리거 버튼 aria-label — 기본 '계정 메뉴' */
+  triggerAriaLabel?: string;
+  /** 헤더 영역(이름/이메일/배지) 강조 색상 className — Super Operator 등 */
+  headerClassName?: string;
+  /** 트리거 버튼 className 오버라이드 — Super Operator 등 변형 색상 */
+  triggerClassName?: string;
+  /** 트리거 아이콘 색상 className — 기본 'text-gray-600' */
+  triggerIconClassName?: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function GlobalUserProfileDropdown({
+  user,
+  menuItems,
+  onLogout,
+  logoutLabel = '로그아웃',
+  trigger = 'click',
+  align = 'right',
+  widthClassName = 'w-64',
+  className,
+  triggerAriaLabel = '계정 메뉴',
+  headerClassName,
+  triggerClassName,
+  triggerIconClassName,
+}: GlobalUserProfileDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // outside click 닫기 (click 트리거에서만 활성화)
+  useEffect(() => {
+    if (trigger !== 'click' || !isOpen) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [trigger, isOpen]);
+
+  // ESC 닫기
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen]);
+
+  const close = () => setIsOpen(false);
+
+  const handleLogout = () => {
+    close();
+    onLogout();
+  };
+
+  const wrapperProps =
+    trigger === 'hover'
+      ? {
+          onMouseEnter: () => setIsOpen(true),
+          onMouseLeave: () => setIsOpen(false),
+        }
+      : {};
+
+  const alignClass = align === 'right' ? 'right-0' : 'left-0';
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={`relative ${className ?? ''}`.trim()}
+      {...wrapperProps}
+    >
+      <button
+        type="button"
+        onClick={trigger === 'click' ? () => setIsOpen((v) => !v) : undefined}
+        className={
+          triggerClassName ??
+          'flex items-center justify-center w-10 h-10 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500'
+        }
+        aria-label={triggerAriaLabel}
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+      >
+        <User className={`w-5 h-5 ${triggerIconClassName ?? 'text-gray-600'}`} />
+      </button>
+
+      {isOpen && (
+        <div
+          className={`absolute ${alignClass} top-full pt-2 z-50`}
+        >
+          <div
+            className={`${widthClassName} bg-white rounded-lg shadow-lg border border-gray-200 py-2`}
+            role="menu"
+          >
+          {/* 사용자 정보 */}
+          <div className={`px-4 py-3 border-b border-gray-100 ${headerClassName ?? ''}`.trim()}>
+            <p className="text-sm font-medium text-gray-900 truncate">{user.displayName}</p>
+            {user.email && (
+              <p className="text-xs text-gray-500 truncate">{user.email}</p>
+            )}
+            {user.roleLabel && (
+              <p className="text-xs mt-1 text-gray-500">{user.roleLabel}</p>
+            )}
+            {user.badge && <div className="mt-1">{user.badge}</div>}
+          </div>
+
+          {/* 메뉴 항목 */}
+          {menuItems.length > 0 && (
+            <div className="py-1">
+              {menuItems.map((item) => (
+                <MenuRow key={item.key} item={item} onNavigate={close} />
+              ))}
+            </div>
+          )}
+
+          {/* 구분선 + 로그아웃 */}
+          <div className="border-t border-gray-100 my-1" />
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="flex items-center gap-3 w-full px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            role="menuitem"
+          >
+            <LogOut className="w-4 h-4 text-gray-500" />
+            {logoutLabel}
+          </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Menu Row ─────────────────────────────────────────────────────────────────
+
+function MenuRow({
+  item,
+  onNavigate,
+}: {
+  item: GlobalUserProfileMenuItem;
+  onNavigate: () => void;
+}) {
+  if (item.node !== undefined) {
+    const content = typeof item.node === 'function' ? item.node(onNavigate) : item.node;
+    return <>{content}</>;
+  }
+
+  const baseClass =
+    'flex items-center gap-3 px-4 py-2.5 text-sm transition-colors hover:bg-gray-50';
+  const colorClass =
+    item.variant === 'highlighted' ? 'text-blue-700' : 'text-gray-700';
+  const className = `${baseClass} ${colorClass}`;
+
+  if (item.href) {
+    return (
+      <Link
+        to={item.href}
+        onClick={onNavigate}
+        className={className}
+        role="menuitem"
+      >
+        {item.icon}
+        {item.label}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        item.onClick?.();
+        onNavigate();
+      }}
+      className={`${className} w-full text-left`}
+      role="menuitem"
+    >
+      {item.icon}
+      {item.label}
+    </button>
+  );
+}
+
+export default GlobalUserProfileDropdown;

--- a/packages/account-ui/src/index.ts
+++ b/packages/account-ui/src/index.ts
@@ -7,5 +7,13 @@ export { QuickActionsSection } from './components/QuickActionsSection.js';
 export { MyPageNavigation } from './components/MyPageNavigation.js';
 export { MyPageLayout } from './components/MyPageLayout.js';
 export { SettingsSection } from './components/SettingsSection.js';
+export { GlobalUserProfileDropdown } from './components/GlobalUserProfileDropdown.js';
 export type { MyPageNavItem } from './components/MyPageNavigation.js';
 export type { ProfileField } from './types.js';
+export type {
+  GlobalUserProfileUser,
+  GlobalUserProfileMenuItem,
+  GlobalUserProfileDropdownProps,
+} from './components/GlobalUserProfileDropdown.js';
+export { getUserDisplayName } from './utils/getUserDisplayName.js';
+export type { DisplayNameUser } from './utils/getUserDisplayName.js';

--- a/packages/account-ui/src/utils/getUserDisplayName.ts
+++ b/packages/account-ui/src/utils/getUserDisplayName.ts
@@ -1,0 +1,36 @@
+/**
+ * getUserDisplayName — 사용자 표시 이름 fallback 체인
+ *
+ * WO-O4O-NAME-NORMALIZATION-V1
+ * WO-O4O-GLOBAL-USER-PROFILE-DROPDOWN-EXTRACTION-V1
+ *
+ * 우선순위:
+ *   displayName > lastName+firstName > name(email과 다른 경우) > email prefix > '사용자'
+ */
+
+export interface DisplayNameUser {
+  displayName?: string | null;
+  lastName?: string | null;
+  firstName?: string | null;
+  name?: string | null;
+  email?: string | null;
+}
+
+export function getUserDisplayName(user: DisplayNameUser | null | undefined): string {
+  if (!user) return '사용자';
+
+  if (user.displayName) return user.displayName;
+
+  if (user.lastName || user.firstName) {
+    const fullName = `${user.lastName || ''}${user.firstName || ''}`.trim();
+    if (fullName) return fullName;
+  }
+
+  if (user.name && user.name !== user.email) {
+    return user.name;
+  }
+
+  if (user.email) return user.email.split('@')[0];
+
+  return '사용자';
+}

--- a/services/web-glycopharm/src/components/common/Header.tsx
+++ b/services/web-glycopharm/src/components/common/Header.tsx
@@ -4,20 +4,26 @@
  *   KPA-Society 기준 역할 기반 메뉴 구조
  *   비로그인/일반: 홈 | 포럼 | 강의
  *   약사 로그인: 홈 | 포럼 | 강의 | ─ | 약국 HUB | 내 약국
+ * WO-O4O-GLOBAL-USER-PROFILE-DROPDOWN-EXTRACTION-V1:
+ *   사용자 드롭다운을 @o4o/account-ui 공통 컴포넌트로 교체
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { GLYCOPHARM_ROLES, isPharmacistRole } from '@/lib/role-constants';
 import { glycopharmConfig } from '@o4o/operator-ux-core';
 import { useLoginModal } from '@/contexts/LoginModalContext';
 import {
+  GlobalUserProfileDropdown,
+  getUserDisplayName,
+  type GlobalUserProfileMenuItem,
+} from '@o4o/account-ui';
+import {
   Menu,
   X,
   User,
   LogOut,
-  ChevronDown,
   Activity,
   Home,
   MessageSquare,
@@ -55,7 +61,6 @@ export default function Header() {
   const { openLoginModal } = useLoginModal();
   const navigate = useNavigate();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [userMenuOpen, setUserMenuOpen] = useState(false);
 
   // WO-GLYCOPHARM-ROLE-PREFIX-MIGRATION-V1: glycopharm:pharmacist OR legacy pharmacy
   const isPharmacy = isAuthenticated && user?.roles?.some(r => isPharmacistRole(r));
@@ -73,9 +78,46 @@ export default function Header() {
   const handleLogout = () => {
     logout();
     navigate('/');
-    setUserMenuOpen(false);
     setMobileMenuOpen(false);
   };
+
+  const displayName = getUserDisplayName(user as any);
+
+  const menuItems: GlobalUserProfileMenuItem[] = useMemo(() => {
+    const items: GlobalUserProfileMenuItem[] = [];
+    if (showInstructor) {
+      items.push({
+        key: 'instructor',
+        icon: <GraduationCap className="w-4 h-4 text-gray-500" />,
+        label: '강의 대시보드',
+        href: '/instructor',
+      });
+    }
+    if (showDashboard) {
+      items.push({
+        key: 'dashboard',
+        icon: <Shield className="w-4 h-4" />,
+        label: dashboardLabel,
+        href: dashboardPath,
+        variant: 'highlighted',
+      });
+    }
+    items.push(
+      {
+        key: 'mypage',
+        icon: <User className="w-4 h-4 text-gray-500" />,
+        label: '마이페이지',
+        href: '/mypage',
+      },
+      {
+        key: 'settings',
+        icon: <Settings className="w-4 h-4 text-gray-500" />,
+        label: '설정',
+        href: '/mypage/settings',
+      },
+    );
+    return items;
+  }, [showInstructor, showDashboard, dashboardLabel, dashboardPath]);
 
   /** NavLink 활성 스타일 (desktop) */
   const desktopNavClass = (isActive: boolean) =>
@@ -140,86 +182,12 @@ export default function Header() {
           {/* Desktop User Actions */}
           <div className="hidden md:flex items-center gap-3">
             {isAuthenticated && <ServiceSwitcher currentServiceKey="glycopharm" />}
-            {isAuthenticated ? (
-              <div className="relative">
-                <button
-                  onClick={() => setUserMenuOpen(!userMenuOpen)}
-                  className="flex items-center gap-1 px-2 py-2 rounded-xl hover:bg-slate-100 transition-colors"
-                >
-                  <div className="w-9 h-9 rounded-full bg-gradient-to-br from-primary-400 to-primary-600 flex items-center justify-center">
-                    <User className="w-5 h-5 text-white" />
-                  </div>
-                  <ChevronDown className="w-4 h-4 text-slate-400" />
-                </button>
-
-                {userMenuOpen && (
-                  <>
-                    <div
-                      className="fixed inset-0 z-40"
-                      onClick={() => setUserMenuOpen(false)}
-                    />
-                    <div className="absolute right-0 top-full mt-2 w-48 bg-white rounded-xl shadow-lg border py-2 z-50 animate-slide-in-right">
-                      <div className="px-4 py-2 border-b">
-                        <p className="text-sm font-medium text-slate-800">
-                          {/* WO-O4O-NAME-NORMALIZATION-V1 */}
-                          {(user as any)?.displayName
-                            || (((user as any)?.lastName || (user as any)?.firstName) ? `${(user as any).lastName || ''}${(user as any).firstName || ''}`.trim() : '')
-                            || (user?.name && user.name !== user.email ? user.name : '')
-                            || user?.email?.split('@')[0]
-                            || '사용자'}
-                        </p>
-                        <p className="text-xs text-slate-500">{user?.email}</p>
-                      </div>
-                      {/* 강의 대시보드 — 최상단 (WO-O4O-INSTRUCTOR-DASHBOARD-ENTRY-V1)
-                       * lms:instructor 또는 glycopharm:admin/platform:super_admin 만 노출 */}
-                      {showInstructor && (
-                        <NavLink
-                          to="/instructor"
-                          className="flex items-center gap-2 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50"
-                          onClick={() => setUserMenuOpen(false)}
-                        >
-                          <GraduationCap className="w-4 h-4" />
-                          강의 대시보드
-                        </NavLink>
-                      )}
-                      {showDashboard && (
-                        <NavLink
-                          to={dashboardPath}
-                          className="flex items-center gap-2 px-4 py-2 text-sm text-blue-700 hover:bg-blue-50"
-                          onClick={() => setUserMenuOpen(false)}
-                        >
-                          <Shield className="w-4 h-4" />
-                          {dashboardLabel}
-                        </NavLink>
-                      )}
-                      <NavLink
-                        to="/mypage"
-                        className="flex items-center gap-2 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50"
-                        onClick={() => setUserMenuOpen(false)}
-                      >
-                        <User className="w-4 h-4" />
-                        마이페이지
-                      </NavLink>
-                      <NavLink
-                        to="/mypage/settings"
-                        className="flex items-center gap-2 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50"
-                        onClick={() => setUserMenuOpen(false)}
-                      >
-                        <Settings className="w-4 h-4" />
-                        설정
-                      </NavLink>
-                      {/* Account Center — 임시 숨김: account.neture.co.kr 서비스 미배포/SSL 미구성 (WO-O4O-ACCOUNT-CENTER-LINK-VISIBILITY-POLICY-ALIGNMENT-V1) */}
-                      <button
-                        onClick={handleLogout}
-                        className="flex items-center gap-2 w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50"
-                      >
-                        <LogOut className="w-4 h-4" />
-                        로그아웃
-                      </button>
-                    </div>
-                  </>
-                )}
-              </div>
+            {isAuthenticated && user ? (
+              <GlobalUserProfileDropdown
+                user={{ displayName, email: user.email }}
+                menuItems={menuItems}
+                onLogout={handleLogout}
+              />
             ) : (
               <>
                 <button

--- a/services/web-k-cosmetics/src/components/common/Header.tsx
+++ b/services/web-k-cosmetics/src/components/common/Header.tsx
@@ -2,11 +2,17 @@
  * Header - K-Cosmetics
  * Based on GlycoPharm Header structure
  * WO-O4O-AUTH-MODAL-LOGIN-AND-ACCOUNT-STANDARD-V1: 중앙화된 LoginModal 사용
+ * WO-O4O-GLOBAL-USER-PROFILE-DROPDOWN-EXTRACTION-V1: 사용자 드롭다운을 공통 컴포넌트로 교체
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { User } from 'lucide-react';
+import { LayoutDashboard } from 'lucide-react';
+import {
+  GlobalUserProfileDropdown,
+  getUserDisplayName,
+  type GlobalUserProfileMenuItem,
+} from '@o4o/account-ui';
 import { useAuth, ROLE_LABELS, getKCosmeticsDashboardRoute } from '@/contexts/AuthContext';
 import { useLoginModal } from '@/contexts/LoginModalContext';
 import ServiceSwitcher from '../ServiceSwitcher';
@@ -16,43 +22,33 @@ export default function Header() {
   const { openLoginModal } = useLoginModal();
   const navigate = useNavigate();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [userMenuOpen, setUserMenuOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  // Close dropdown on ESC key
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setUserMenuOpen(false);
-    };
-    if (userMenuOpen) {
-      document.addEventListener('keydown', handleKeyDown);
-      return () => document.removeEventListener('keydown', handleKeyDown);
-    }
-  }, [userMenuOpen]);
-
-  // Close dropdown on click outside
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setUserMenuOpen(false);
-      }
-    };
-    if (userMenuOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
-    }
-  }, [userMenuOpen]);
 
   const handleLogout = () => {
     logout();
     navigate('/');
-    setUserMenuOpen(false);
     setMobileMenuOpen(false);
   };
 
   const dashboardPath = user?.roles[0] ? getKCosmeticsDashboardRoute(user.roles) : '/';
   const roleLabel = user?.roles[0] ? ROLE_LABELS[user.roles[0]] : '';
   const isStoreOwner = user?.roles.includes('cosmetics:store_owner') ?? false;
+
+  const displayName = getUserDisplayName(user as any);
+
+  const menuItems: GlobalUserProfileMenuItem[] = useMemo(() => [
+    {
+      key: 'dashboard',
+      icon: <LayoutDashboard className="w-4 h-4 text-gray-500" />,
+      label: '대시보드',
+      href: dashboardPath,
+    },
+    {
+      key: 'mypage',
+      icon: <LayoutDashboard className="w-4 h-4 text-gray-500" />,
+      label: '마이페이지',
+      href: '/mypage',
+    },
+  ], [dashboardPath]);
 
   return (
     <header style={styles.header}>
@@ -85,56 +81,12 @@ export default function Header() {
           {/* Desktop User Actions */}
           <div style={styles.actions}>
             {isAuthenticated && <ServiceSwitcher currentServiceKey="k-cosmetics" />}
-            {isAuthenticated ? (
-              <div style={styles.userMenu} ref={dropdownRef}>
-                <button
-                  onClick={() => setUserMenuOpen(!userMenuOpen)}
-                  style={styles.userButton}
-                  aria-label="사용자 메뉴"
-                >
-                  <div style={styles.avatar}>
-                    <User style={{ width: 20, height: 20, color: '#fff' }} />
-                  </div>
-                </button>
-
-                {userMenuOpen && (
-                  <div style={styles.dropdown}>
-                    <div style={styles.dropdownHeader}>
-                      <p style={styles.dropdownName}>
-                        {/* WO-O4O-NAME-NORMALIZATION-V1 */}
-                        {(user as any)?.displayName
-                          || (((user as any)?.lastName || (user as any)?.firstName) ? `${(user as any).lastName || ''}${(user as any).firstName || ''}`.trim() : '')
-                          || (user?.name && user.name !== user.email ? user.name : '')
-                          || user?.email?.split('@')[0]
-                          || '사용자'}님
-                      </p>
-                      <p style={styles.dropdownEmail}>{user?.email}</p>
-                      <p style={styles.dropdownRole}>{roleLabel}</p>
-                    </div>
-                    <Link
-                      to={dashboardPath}
-                      style={styles.dropdownItem}
-                      onClick={() => setUserMenuOpen(false)}
-                    >
-                      대시보드
-                    </Link>
-                    <Link
-                      to="/mypage"
-                      style={styles.dropdownItem}
-                      onClick={() => setUserMenuOpen(false)}
-                    >
-                      마이페이지
-                    </Link>
-                    {/* Account Center — 임시 숨김: account.neture.co.kr 서비스 미배포/SSL 미구성 (WO-O4O-ACCOUNT-CENTER-LINK-VISIBILITY-POLICY-ALIGNMENT-V1) */}
-                    <button
-                      onClick={handleLogout}
-                      style={styles.dropdownLogout}
-                    >
-                      로그아웃
-                    </button>
-                  </div>
-                )}
-              </div>
+            {isAuthenticated && user ? (
+              <GlobalUserProfileDropdown
+                user={{ displayName, email: user.email, roleLabel }}
+                menuItems={menuItems}
+                onLogout={handleLogout}
+              />
             ) : (
               <>
                 <button onClick={openLoginModal} style={styles.loginLink}>로그인</button>
@@ -270,90 +222,6 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     gap: '12px',
-  },
-  userMenu: {
-    position: 'relative',
-  },
-  userButton: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: '4px',
-    borderRadius: '50%',
-    border: 'none',
-    background: 'transparent',
-    cursor: 'pointer',
-    transition: 'background-color 0.2s',
-  },
-  avatar: {
-    width: '36px',
-    height: '36px',
-    borderRadius: '50%',
-    background: 'linear-gradient(135deg, #f48fb1, #e91e63)',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    color: '#fff',
-    fontSize: '15px',
-    fontWeight: 600,
-    boxShadow: '0 2px 8px rgba(233, 30, 99, 0.3)',
-  },
-  dropdown: {
-    position: 'absolute',
-    right: 0,
-    top: '100%',
-    marginTop: '8px',
-    width: '192px',
-    backgroundColor: '#fff',
-    borderRadius: '12px',
-    boxShadow: '0 10px 40px rgba(0,0,0,0.15)',
-    border: '1px solid #e2e8f0',
-    padding: '8px 0',
-    zIndex: 50,
-  },
-  dropdownHeader: {
-    padding: '12px 16px',
-    borderBottom: '1px solid #e2e8f0',
-  },
-  dropdownName: {
-    fontSize: '14px',
-    fontWeight: 600,
-    color: '#1e293b',
-    margin: '0 0 4px 0',
-  },
-  dropdownEmail: {
-    fontSize: '13px',
-    fontWeight: 500,
-    color: '#1e293b',
-    margin: 0,
-  },
-  dropdownRole: {
-    fontSize: '11px',
-    color: '#e91e63',
-    margin: '2px 0 0 0',
-    fontWeight: 500,
-  },
-  dropdownItem: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    padding: '10px 16px',
-    fontSize: '14px',
-    color: '#334155',
-    textDecoration: 'none',
-  },
-  dropdownLogout: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    width: '100%',
-    padding: '10px 16px',
-    fontSize: '14px',
-    color: '#dc2626',
-    background: 'transparent',
-    border: 'none',
-    cursor: 'pointer',
-    textAlign: 'left',
   },
   loginLink: {
     padding: '8px 16px',

--- a/services/web-kpa-society/src/components/Header.tsx
+++ b/services/web-kpa-society/src/components/Header.tsx
@@ -5,13 +5,19 @@
  * WO-KPA-SOCIETY-SERVICE-STRUCTURE-BASELINE-V1: 3개 서비스 구조 기준
  * WO-KPA-SUPER-OPERATOR-BASELINE-REFINE-V1: Super Operator 공통 메뉴 지원
  * WO-KPA-A-ROLE-BASED-NAVIGATION-AND-ENTRY-REFINEMENT-V1: 공개/역할 메뉴 분리 + dropdown 진입점
+ * WO-O4O-GLOBAL-USER-PROFILE-DROPDOWN-EXTRACTION-V1: 사용자 드롭다운을 @o4o/account-ui 공통 컴포넌트로 교체 (hover 트리거 + Super Operator 배지/색상 보존)
  *
  * 원칙: 상단 메뉴는 서비스 진입점만 노출 (기능 나열 금지)
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { User, LayoutDashboard, Settings, LogOut, Shield, GraduationCap } from 'lucide-react';
+import { LayoutDashboard, Shield, GraduationCap } from 'lucide-react';
+import {
+  GlobalUserProfileDropdown,
+  getUserDisplayName,
+  type GlobalUserProfileMenuItem,
+} from '@o4o/account-ui';
 import { useAuth, type User as UserType } from '../contexts';
 import { useAuthModal } from '../contexts/LoginModalContext';
 import { colors } from '../styles/theme';
@@ -28,35 +34,6 @@ function isSuperOperator(user: UserType | null): boolean {
   if (!user) return false;
   if ((user as any).isSuperOperator) return true;
   return hasAnyRole(user.roles, SUPER_OPERATOR_ROLES);
-}
-
-/**
- * WO-O4O-NAME-NORMALIZATION-V1: 사용자 표시 이름 헬퍼
- * 우선순위: displayName > lastName+firstName > name > email prefix > '사용자'
- */
-function getUserDisplayName(user: UserType | null): string {
-  if (!user) return '사용자';
-
-  const extendedUser = user as any;
-
-  // 1. API computed displayName
-  if (extendedUser.displayName) return extendedUser.displayName;
-
-  // 2. lastName + firstName 조합
-  if (extendedUser.lastName || extendedUser.firstName) {
-    const fullName = `${extendedUser.lastName || ''}${extendedUser.firstName || ''}`.trim();
-    if (fullName) return fullName;
-  }
-
-  // 3. name 필드 (이메일과 다른 경우에만)
-  if (user.name && user.name !== user.email) {
-    return user.name;
-  }
-
-  // 4. email prefix
-  if (user.email) return user.email.split('@')[0];
-
-  return '사용자';
 }
 
 interface MenuItem {
@@ -90,7 +67,6 @@ export function Header({ serviceName }: { serviceName: string }) {
   const navigate = useNavigate();
   const [activeMenu, setActiveMenu] = useState<string | null>(null);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [showUserDropdown, setShowUserDropdown] = useState(false);
 
   const accessibleDashboards = useAccessibleDashboards();
 
@@ -105,6 +81,8 @@ export function Header({ serviceName }: { serviceName: string }) {
   const isInstructor = user ? user.roles.includes(ROLES.LMS_INSTRUCTOR) : false;
   const isStoreOwner = user?.isStoreOwner === true;
   const isPharmacyRelated = isStoreOwner || (user as any)?.activityType === 'pharmacy_owner';
+  const isSuperOp = isSuperOperator(user);
+
   const displayMenuItems = menuItems
     .map(item => {
       // admin이면 "운영 대시보드" → "관리자 콘솔" + /admin
@@ -130,6 +108,79 @@ export function Header({ serviceName }: { serviceName: string }) {
     await logout();
     navigate('/');
   };
+
+  const displayName = getUserDisplayName(user as any);
+
+  // 사용자 드롭다운 메뉴 항목 (기존 분기 로직 보존)
+  const dropdownMenuItems: GlobalUserProfileMenuItem[] = useMemo(() => {
+    if (!user) return [];
+
+    // Super Operator: 간소화된 메뉴
+    if (isSuperOp) {
+      return [
+        {
+          key: 'dashboard',
+          icon: <Shield className="w-4 h-4 text-amber-600" />,
+          label: isAdmin ? '관리자 콘솔' : '운영 대시보드',
+          href: isAdmin ? '/admin' : '/operator',
+        },
+        {
+          key: 'mypage',
+          icon: <LayoutDashboard className="w-4 h-4 text-gray-500" />,
+          label: '마이페이지',
+          href: '/mypage',
+        },
+      ];
+    }
+
+    // 일반 사용자: 전체 메뉴
+    const items: GlobalUserProfileMenuItem[] = [];
+
+    // 강의 대시보드 (WO-O4O-INSTRUCTOR-DASHBOARD-ENTRY-V1)
+    if (isInstructor || isAdmin) {
+      items.push({
+        key: 'instructor',
+        icon: <GraduationCap className="w-4 h-4 text-gray-500" />,
+        label: '강의 대시보드',
+        href: '/instructor',
+      });
+    }
+
+    // 운영/관리 진입점 (WO-KPA-OPERATOR-USER-MENU-CLEANUP-V1)
+    if (isAdmin || isOperator) {
+      items.push({
+        key: 'admin-console',
+        icon: <Shield className="w-4 h-4 text-gray-500" />,
+        label: isAdmin ? '관리자 콘솔' : '운영 대시보드',
+        href: isAdmin ? '/admin' : '/operator',
+      });
+    }
+
+    // 다중 대시보드 접근 가능 시 DashboardSwitcher, 아니면 단순 마이페이지 링크
+    // WO-KPA-SOCIETY-DASHBOARD-TO-MYPAGE-CONSOLIDATION-V1
+    if (accessibleDashboards.length >= 2) {
+      items.push({
+        key: 'dashboard-switcher',
+        node: (close) => <DashboardSwitcher onNavigate={close} />,
+      });
+    } else {
+      items.push({
+        key: 'mypage',
+        icon: <LayoutDashboard className="w-4 h-4 text-gray-500" />,
+        label: '마이페이지',
+        href: '/mypage',
+      });
+    }
+
+    items.push({
+      key: 'settings',
+      icon: <LayoutDashboard className="w-4 h-4 text-gray-500" />,
+      label: '설정',
+      href: '/mypage/settings',
+    });
+
+    return items;
+  }, [user, isSuperOp, isAdmin, isOperator, isInstructor, accessibleDashboards.length]);
 
   return (
     <>
@@ -201,129 +252,26 @@ export function Header({ serviceName }: { serviceName: string }) {
           <div style={styles.authArea}>
             {user && <ServiceSwitcher currentServiceKey="kpa-society" />}
             {user ? (
-              <div
-                style={styles.userIconWrapper}
-                onMouseEnter={() => setShowUserDropdown(true)}
-                onMouseLeave={() => setShowUserDropdown(false)}
-              >
-                {/* Super Operator는 다른 아이콘/색상 */}
-                <button
-                  style={{
-                    ...styles.userIconButton,
-                    ...(isSuperOperator(user) ? styles.operatorIconButton : {}),
-                  }}
-                  aria-label="사용자 메뉴"
-                >
-                  <User style={{ width: 20, height: 20, color: isSuperOperator(user) ? '#d97706' : colors.gray600 }} />
-                </button>
-                {showUserDropdown && (
-                  <div style={styles.userDropdown}>
-                    <div style={styles.userDropdownInner}>
-                      <div style={{
-                        ...styles.userDropdownHeader,
-                        ...(isSuperOperator(user) ? styles.operatorDropdownHeader : {}),
-                      }}>
-                        <span style={styles.userDropdownName}>{getUserDisplayName(user)}님</span>
-                        <span style={styles.userDropdownEmail}>{user.email}</span>
-                        {isSuperOperator(user) && (
-                          <span style={styles.operatorBadge}>🛡️ Super Operator</span>
-                        )}
-                      </div>
-                      <div style={styles.userDropdownDivider} />
-
-                      {/* Super Operator: 간소화된 메뉴 */}
-                      {isSuperOperator(user) ? (
-                        <>
-                          <Link
-                            to={isAdmin ? '/admin' : '/operator'}
-                            style={styles.userDropdownItem}
-                            onClick={() => setShowUserDropdown(false)}
-                          >
-                            <Shield style={{ width: 16, height: 16, color: '#d97706' }} />
-                            {isAdmin ? '관리자 콘솔' : '운영 대시보드'}
-                          </Link>
-                          <Link
-                            to="/mypage"
-                            style={styles.userDropdownItem}
-                            onClick={() => setShowUserDropdown(false)}
-                          >
-                            <LayoutDashboard style={{ width: 16, height: 16, color: colors.gray500 }} />
-                            마이페이지
-                          </Link>
-                        </>
-                      ) : (
-                        /* 일반 사용자: 전체 메뉴
-                         * DashboardSwitcher: 2개 이상 대시보드 접근 가능 시 표시 (KPA 전용)
-                         * - "마이페이지" (/mypage): 모든 인증 사용자
-                         * - "약국경영" (/pharmacy): pharmacy context + non-admin/operator
-                         * 1개만 접근 가능하면 단순 마이페이지 링크 표시
-                         * WO-KPA-SOCIETY-DASHBOARD-TO-MYPAGE-CONSOLIDATION-V1
-                         */
-                        <>
-                          {/* 강의 대시보드 — 최상단 (WO-O4O-INSTRUCTOR-DASHBOARD-ENTRY-V1)
-                           * lms:instructor 또는 kpa:admin 만 노출. kpa:operator 는 /operator/lms 사용. */}
-                          {(isInstructor || isAdmin) && (
-                            <Link
-                              to="/instructor"
-                              style={styles.userDropdownItem}
-                              onClick={() => setShowUserDropdown(false)}
-                            >
-                              <GraduationCap style={{ width: 16, height: 16, color: colors.gray500 }} />
-                              강의 대시보드
-                            </Link>
-                          )}
-                          {/* 운영/관리 진입점 (WO-KPA-OPERATOR-USER-MENU-CLEANUP-V1) */}
-                          {(isAdmin || isOperator) && (
-                            <Link
-                              to={isAdmin ? '/admin' : '/operator'}
-                              style={styles.userDropdownItem}
-                              onClick={() => setShowUserDropdown(false)}
-                            >
-                              <Shield style={{ width: 16, height: 16, color: colors.gray500 }} />
-                              {isAdmin ? '관리자 콘솔' : '운영 대시보드'}
-                            </Link>
-                          )}
-                          {accessibleDashboards.length >= 2 ? (
-                            <>
-                              <DashboardSwitcher onNavigate={() => setShowUserDropdown(false)} />
-                            </>
-                          ) : (
-                            <Link
-                              to="/mypage"
-                              style={styles.userDropdownItem}
-                              onClick={() => setShowUserDropdown(false)}
-                            >
-                              <LayoutDashboard style={{ width: 16, height: 16, color: colors.gray500 }} />
-                              마이페이지
-                            </Link>
-                          )}
-                          <Link
-                            to="/mypage/settings"
-                            style={styles.userDropdownItem}
-                            onClick={() => setShowUserDropdown(false)}
-                          >
-                            <Settings style={{ width: 16, height: 16, color: colors.gray500 }} />
-                            설정
-                          </Link>
-                        </>
-                      )}
-
-                      {/* Account Center — 임시 숨김: account.neture.co.kr 서비스 미배포/SSL 미구성 (WO-KPA-SOCIETY-HIDE-BROKEN-ACCOUNT-CENTER-LINK-V1) */}
-                      <div style={styles.userDropdownDivider} />
-                      <button
-                        style={styles.userDropdownLogout}
-                        onClick={() => {
-                          setShowUserDropdown(false);
-                          handleLogout();
-                        }}
-                      >
-                        <LogOut style={{ width: 16, height: 16, color: colors.error || '#dc2626' }} />
-                        로그아웃
-                      </button>
-                    </div>
-                  </div>
-                )}
-              </div>
+              <GlobalUserProfileDropdown
+                user={{
+                  displayName,
+                  email: user.email,
+                  badge: isSuperOp ? (
+                    <span className="text-xs font-semibold text-amber-700">🛡️ Super Operator</span>
+                  ) : undefined,
+                }}
+                menuItems={dropdownMenuItems}
+                onLogout={handleLogout}
+                trigger="hover"
+                triggerClassName={
+                  isSuperOp
+                    ? 'flex items-center justify-center w-10 h-10 rounded-full bg-amber-100 border border-amber-500 hover:bg-amber-200 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500'
+                    : 'flex items-center justify-center w-10 h-10 rounded-full bg-gray-100 border border-gray-300 hover:bg-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500'
+                }
+                triggerIconClassName={isSuperOp ? 'text-amber-600' : 'text-gray-600'}
+                headerClassName={isSuperOp ? 'bg-amber-50' : undefined}
+                widthClassName="w-[220px]"
+              />
             ) : (
               <>
                 <button
@@ -501,101 +449,6 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     gap: '10px',
-  },
-  userIconWrapper: {
-    position: 'relative',
-  },
-  userIconButton: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '40px',
-    height: '40px',
-    borderRadius: '50%',
-    backgroundColor: colors.gray100,
-    border: `1px solid ${colors.gray300}`,
-    cursor: 'pointer',
-    transition: 'background-color 0.2s, border-color 0.2s',
-  },
-  userIcon: {
-    fontSize: '20px',
-  },
-  userDropdown: {
-    position: 'absolute',
-    top: '100%',
-    right: 0,
-    paddingTop: '8px',  // Use paddingTop instead of marginTop to keep hover area connected
-    backgroundColor: 'transparent',
-    zIndex: 100,
-  },
-  userDropdownInner: {
-    backgroundColor: colors.white,
-    borderRadius: '12px',
-    boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
-    minWidth: '220px',
-    padding: '8px 0',
-  },
-  userDropdownHeader: {
-    padding: '12px 16px',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '4px',
-  },
-  userDropdownName: {
-    fontSize: '15px',
-    fontWeight: 600,
-    color: colors.gray900,
-  },
-  userDropdownEmail: {
-    fontSize: '12px',
-    color: colors.gray500,
-    wordBreak: 'break-all',
-  },
-  userDropdownDivider: {
-    height: '1px',
-    backgroundColor: colors.gray200,
-    margin: '4px 0',
-  },
-  userDropdownItem: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '10px',
-    padding: '10px 16px',
-    color: colors.gray700,
-    textDecoration: 'none',
-    fontSize: '14px',
-    transition: 'background-color 0.2s',
-  },
-  userDropdownItemIcon: {
-    fontSize: '16px',
-  },
-  userDropdownLogout: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '10px',
-    width: '100%',
-    padding: '10px 16px',
-    color: colors.error || '#dc2626',
-    backgroundColor: 'transparent',
-    border: 'none',
-    fontSize: '14px',
-    cursor: 'pointer',
-    textAlign: 'left',
-    transition: 'background-color 0.2s',
-  },
-  // WO-KPA-SUPER-OPERATOR-BASELINE-REFINE-V1: Super Operator 스타일
-  operatorIconButton: {
-    backgroundColor: '#fef3c7',
-    borderColor: '#f59e0b',
-  },
-  operatorDropdownHeader: {
-    backgroundColor: '#fffbeb',
-  },
-  operatorBadge: {
-    marginTop: '4px',
-    fontSize: '11px',
-    fontWeight: 600,
-    color: '#d97706',
   },
   authButton: {
     padding: '10px 20px',

--- a/services/web-kpa-society/tailwind.config.js
+++ b/services/web-kpa-society/tailwind.config.js
@@ -6,6 +6,7 @@ export default {
     "../../packages/operator-core/src/**/*.{ts,tsx}",
     "../../packages/store-ui-core/src/**/*.{ts,tsx}",
     "../../packages/ui/src/**/*.{ts,tsx}",
+    "../../packages/account-ui/src/**/*.{ts,tsx}",
     "../../packages/shared-space-ui/src/**/*.{ts,tsx}",
   ],
   theme: {

--- a/services/web-neture/src/components/AccountMenu.tsx
+++ b/services/web-neture/src/components/AccountMenu.tsx
@@ -1,60 +1,36 @@
 /**
  * AccountMenu - 상단 계정 영역 UI
- * WO-NETURE-UI-ACCOUNT-MENU-V1
- * WO-O4O-AUTH-RBAC-CLEANUP-V1: isSuperOperator 제거, 단일 메뉴 통합
  *
- * 프로필 아이콘 + 드롭다운 메뉴
- * - 역할에 관계없이 단일 메뉴 구조
- * - admin/operator → 대시보드 링크 표시
+ * WO-O4O-GLOBAL-USER-PROFILE-DROPDOWN-EXTRACTION-V1
+ *   드롭다운 UI를 @o4o/account-ui의 GlobalUserProfileDropdown으로 교체.
+ *   Neture 역할별 dashboard route 결정 로직은 본 wrapper에 유지.
+ *
+ * 비로그인 상태(로그인/회원가입 버튼)는 기존 동선 유지.
  */
 
-import { useState, useRef, useEffect } from 'react';
-import { Link, useNavigate, useLocation } from 'react-router-dom';
-import { User, LogOut, LayoutDashboard } from 'lucide-react';
+import { useMemo } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { LayoutDashboard } from 'lucide-react';
+import {
+  GlobalUserProfileDropdown,
+  getUserDisplayName,
+  type GlobalUserProfileMenuItem,
+} from '@o4o/account-ui';
 
 import { useAuth, getNetureDashboardRoute, getNetureRoleLabel, useLoginModal } from '../contexts';
 
 export default function AccountMenu() {
   const { user, isAuthenticated, logout } = useAuth();
   const { openLoginModal, openRegisterModal } = useLoginModal();
-  const [isOpen, setIsOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
   const location = useLocation();
 
-  // 외부 클릭 시 메뉴 닫기
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  // ESC 키로 메뉴 닫기
-  useEffect(() => {
-    function handleEscKey(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        setIsOpen(false);
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscKey);
-      return () => document.removeEventListener('keydown', handleEscKey);
-    }
-  }, [isOpen]);
-
   const handleLogout = async () => {
-    setIsOpen(false);
     await logout();
     navigate('/');
   };
 
-  // 비로그인 상태: 로그인 + 회원가입
+  // 비로그인 상태
   if (!isAuthenticated || !user) {
     return (
       <div className="flex items-center gap-2">
@@ -74,92 +50,48 @@ export default function AccountMenu() {
     );
   }
 
-  // WO-O4O-NETURE-AUTH-ROLE-REDIRECT-FIX-V1: 전체 roles로 대시보드 경로 결정
+  // WO-O4O-NETURE-AUTH-ROLE-REDIRECT-FIX-V1: 전체 roles로 dashboard 경로 결정
   const dashboardPath = getNetureDashboardRoute(user.roles);
-  // 우선순위 기반 라벨 — roles[0] 단독 사용 시 Operator에게도 '사용자'가 표시되는 문제 방지
   const roleLabel = getNetureRoleLabel(user.roles);
 
-  // WO-O4O-AUTH-RBAC-CLEANUP-V1: 대시보드 대상 판별 (prefixed + unprefixed)
+  // WO-O4O-AUTH-RBAC-CLEANUP-V1: 대시보드 대상 역할 판별
   const DASHBOARD_ROLES = ['supplier', 'partner', 'seller'];
   const hasDashboardRole = user.roles?.some((r: string) =>
-    r.endsWith(':admin') || r.endsWith(':operator') || r.endsWith(':supplier') || r.endsWith(':partner') || r.endsWith(':seller') || r === 'platform:super_admin' || DASHBOARD_ROLES.includes(r)
+    r.endsWith(':admin') ||
+    r.endsWith(':operator') ||
+    r.endsWith(':supplier') ||
+    r.endsWith(':partner') ||
+    r.endsWith(':seller') ||
+    r === 'platform:super_admin' ||
+    DASHBOARD_ROLES.includes(r),
   ) ?? false;
 
-  // WO-O4O-NAME-NORMALIZATION-V1: displayName > lastName+firstName > name > email prefix > '사용자'
-  const extUser = user as any;
-  const displayName = extUser.displayName
-    || ((extUser.lastName || extUser.firstName) ? `${extUser.lastName || ''}${extUser.firstName || ''}`.trim() : '')
-    || (user.name && user.name !== user.email ? user.name : '')
-    || user.email?.split('@')[0]
-    || '사용자';
+  const displayName = getUserDisplayName(user as any);
+
+  const menuItems: GlobalUserProfileMenuItem[] = useMemo(() => {
+    const items: GlobalUserProfileMenuItem[] = [];
+    if (hasDashboardRole) {
+      items.push({
+        key: 'dashboard',
+        icon: <LayoutDashboard className="w-4 h-4 text-gray-500" />,
+        label: `${roleLabel} 대시보드`,
+        href: dashboardPath,
+      });
+    }
+    items.push({
+      key: 'mypage',
+      icon: <LayoutDashboard className="w-4 h-4 text-gray-500" />,
+      label: '마이페이지',
+      href: '/mypage',
+    });
+    return items;
+  }, [hasDashboardRole, roleLabel, dashboardPath]);
 
   return (
-    <div ref={menuRef} className="relative">
-      {/* 프로필 아이콘 버튼 */}
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-center w-10 h-10 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-        aria-label="계정 메뉴"
-        aria-expanded={isOpen}
-        aria-haspopup="true"
-      >
-        <User className="w-5 h-5 text-gray-600" />
-      </button>
-
-      {/* 드롭다운 메뉴 */}
-      {isOpen && (
-        <div className="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
-          {/* 사용자 정보 */}
-          <div className="px-4 py-3 border-b border-gray-100">
-            <p className="text-sm font-medium text-gray-900 truncate">
-              {displayName}
-            </p>
-            <p className="text-xs text-gray-500 truncate">
-              {user.email}
-            </p>
-            <p className="text-xs mt-1 text-gray-500">
-              {roleLabel}
-            </p>
-          </div>
-
-          {/* 메뉴 항목 — WO-O4O-AUTH-RBAC-CLEANUP-V1: 단일 메뉴 구조 */}
-          <div className="py-1">
-            {/* 대시보드 - 대시보드 대상 역할인 경우 최상단 표시 */}
-            {hasDashboardRole && (
-              <Link
-                to={dashboardPath}
-                onClick={() => setIsOpen(false)}
-                className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-              >
-                <LayoutDashboard className="w-4 h-4 text-gray-500" />
-                {roleLabel} 대시보드
-              </Link>
-            )}
-
-            {/* 마이페이지 — WO-O4O-MYPAGE-LABEL-AND-ICON-UNIFICATION-V1: Settings → LayoutDashboard */}
-            <Link
-              to="/mypage"
-              onClick={() => setIsOpen(false)}
-              className="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-            >
-              <LayoutDashboard className="w-4 h-4 text-gray-500" />
-              마이페이지
-            </Link>
-
-            {/* Account Center — 임시 숨김: account.neture.co.kr 서비스 미배포/SSL 미구성 (WO-O4O-ACCOUNT-CENTER-LINK-VISIBILITY-POLICY-ALIGNMENT-V1) */}
-            <div className="border-t border-gray-100 my-1" />
-
-            {/* 로그아웃 */}
-            <button
-              onClick={handleLogout}
-              className="flex items-center gap-3 w-full px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-            >
-              <LogOut className="w-4 h-4 text-gray-500" />
-              로그아웃
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
+    <GlobalUserProfileDropdown
+      user={{ displayName, email: user.email, roleLabel }}
+      menuItems={menuItems}
+      onLogout={handleLogout}
+    />
   );
 }


### PR DESCRIPTION
## Summary
Apply only the Header / user profile / dropdown subset of current WIP to main, while leaving all other in-progress changes (notifications, LMS, content, routing, deps, docs) untouched.

Extracts the user profile dropdown that was duplicated across 4 web services (KPA-Society, GlycoPharm, K-Cosmetics, Neture) into `@o4o/account-ui` as `GlobalUserProfileDropdown`, plus the display-name fallback chain (`getUserDisplayName`). Each service Header keeps its own role/serviceKey logic and passes resolved values as props — no auth context coupling moves into the shared module.

Reference behavior: existing Neture `AccountMenu` (click trigger, outside-close, ESC-close, accessibility attributes).

## Changes (8 files, +532 / -613 net consolidation)

**packages/account-ui** (3 files)
- `src/components/GlobalUserProfileDropdown.tsx` — new shared dropdown
- `src/utils/getUserDisplayName.ts` — new display-name utility
- `src/index.ts` — export the above

**4 service Headers**
- `services/web-glycopharm/src/components/common/Header.tsx`
- `services/web-k-cosmetics/src/components/common/Header.tsx`
- `services/web-kpa-society/src/components/Header.tsx`
- `services/web-neture/src/components/AccountMenu.tsx`

**Tailwind config**
- `services/web-kpa-society/tailwind.config.js` — add `account-ui` to content paths (other 3 services already had it)

## Out of scope (intentionally excluded)
- Notification Bell / API
- LMS, Forum, Content, Resources changes
- Routing changes
- Dependency bumps (`pnpm-lock.yaml`, `package.json`)
- Docs

Working-tree WIP for these areas remains unstaged on the local main and will be handled in separate WOs.

## Test plan
- [x] `npx tsc --noEmit` → 0 errors on packages/account-ui, web-kpa-society, web-glycopharm (tsc -b), web-k-cosmetics, web-neture
- [ ] CI build green for all 4 services + account-ui
- [ ] Visual check after merge: header dropdown opens/closes (click + outside + ESC), shows correct display name, role label, badge

## Branch lifecycle
`temp/*` branch — short-lived. Delete immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)