### PR TITLE
WO-NETURE-COMMUNITY-HUB-TEMPLATE-ADOPTION-MAIN-APPLY-V1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3540,6 +3540,9 @@ importers:
       '@o4o/operator-ux-core':
         specifier: workspace:*
         version: link:../../packages/operator-ux-core
+      '@o4o/shared-space-ui':
+        specifier: workspace:*
+        version: link:../../packages/shared-space-ui
       '@o4o/types':
         specifier: workspace:*
         version: link:../../packages/types

--- a/services/web-neture/package.json
+++ b/services/web-neture/package.json
@@ -21,6 +21,7 @@
     "@o4o/hub-core": "workspace:*",
     "@o4o/operator-core": "workspace:*",
     "@o4o/operator-ux-core": "workspace:*",
+    "@o4o/shared-space-ui": "workspace:*",
     "@o4o/types": "workspace:*",
     "@o4o/ui": "workspace:*",
     "lucide-react": "^0.523.0",

--- a/services/web-neture/src/App.tsx
+++ b/services/web-neture/src/App.tsx
@@ -749,10 +749,7 @@ function App() {
               {/* 파트너 개요 */}
               <Route path="/partner/overview-info" element={<PartnerOverviewInfoPage />} />
 
-              {/* 테스트 센터 포럼 */}
-              <Route path="/forum" element={<ForumPage title="테스트 센터" description="모든 서비스의 테스트 피드백과 의견을 나누는 공간입니다." noticeText="서비스 테스트 후 발견한 문제점, 개선 의견, 질문을 남겨주세요." />} />
-              <Route path="/forum/write" element={<ForumWritePage />} />
-              <Route path="/forum/post/:slug" element={<ForumPostPage />} />
+              {/* /forum, /forum/write, /forum/post/:slug — NetureLayout canonical (WO-NETURE-COMMUNITY-HUB-TEMPLATE-ADOPTION-V1) */}
               <Route path="/forum/service-update" element={<ForumPage boardSlug="service-update" />} />
               <Route path="/forum/service-update/new" element={<ForumWritePage />} />
               <Route path="/forum/service-update/:slug" element={<ForumPostPage />} />

--- a/services/web-neture/src/lib/api/hubContent.ts
+++ b/services/web-neture/src/lib/api/hubContent.ts
@@ -13,6 +13,7 @@ const SERVICE_KEY = 'neture';
 
 interface HubContentListParams {
   sourceDomain?: string;
+  type?: string;
   page?: number;
   limit?: number;
 }
@@ -22,6 +23,7 @@ export const hubContentApi = {
     const searchParams = new URLSearchParams();
     searchParams.set('serviceKey', SERVICE_KEY);
     if (params.sourceDomain) searchParams.set('sourceDomain', params.sourceDomain);
+    if (params.type) searchParams.set('type', params.type);
     if (params.page) searchParams.set('page', String(params.page));
     if (params.limit) searchParams.set('limit', String(params.limit));
 

--- a/services/web-neture/src/pages/forum/ForumHubPage.tsx
+++ b/services/web-neture/src/pages/forum/ForumHubPage.tsx
@@ -1,55 +1,29 @@
 /**
- * ForumHubPage - 포럼 허브 랜딩 페이지
+ * ForumHubPage — Neture 포럼 허브
  *
- * WO-O4O-FORUM-HUB-DAUM-STYLE-REFINEMENT-V1
- * 다음 카페 스타일 포럼 Hub: 카테고리(포럼) 카드 중심 탐색 UX
+ * WO-NETURE-COMMUNITY-HUB-TEMPLATE-ADOPTION-V1
  *
- * ForumHubPage
- * ├─ HeroHeader (포럼 아이덴티티 + 글쓰기 CTA)
- * ├─ ForumCardGrid (카테고리 카드 — 핵심 1차 콘텐츠)
- * ├─ ActivitySection (인기 글 + 최근 글 — 2차 보조)
- * ├─ WritePrompt (글쓰기/로그인 유도 CTA)
- * └─ InfoSection (이용안내 + 바로가기)
+ * ForumHubTemplate + Neture config-only adapter.
+ * basePath prop 으로 /forum, /workspace/forum 동일 컴포넌트 재사용.
  */
 
-import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
-import { PageHero, PageSection, PageContainer } from '@o4o/ui';
+import { useMemo } from 'react';
+import {
+  ForumHubTemplate,
+  type ForumHubConfig,
+  type ForumHubCategory,
+  type ForumHubPost,
+} from '@o4o/shared-space-ui';
 import { useAuth } from '../../contexts';
 import {
-  fetchForumPosts,
-  fetchForumCategories,
   fetchPopularForums,
-  normalizePostType,
+  fetchForumCategories,
+  fetchForumPosts,
   getAuthorName,
   type ForumPost,
   type ForumCategory,
   type PopularForum,
 } from '../../services/forumApi';
-
-// ============================================================================
-// Constants
-// ============================================================================
-
-const DEFAULT_FORUM_ICON = '📂';
-
-const FALLBACK_ICONS: Record<string, string> = {
-  '자유게시판': '💬',
-  '정보공유': '📌',
-  '질문답변': '❓',
-  '후기': '⭐',
-  '공지사항': '📢',
-  'Neture 포럼': '🌿',
-  '테스트 피드백': '🧪',
-  '서비스 업데이트': '🔄',
-  '일반 토론': '💬',
-  '뉴스': '📰',
-  '가이드': '📖',
-};
-
-// ============================================================================
-// Props
-// ============================================================================
 
 interface ForumHubPageProps {
   title?: string;
@@ -57,467 +31,79 @@ interface ForumHubPageProps {
   basePath?: string;
 }
 
-// ============================================================================
-// Helpers
-// ============================================================================
-
-interface DisplayPost {
-  id: string;
-  title: string;
-  slug: string;
-  type: string;
-  authorName: string;
-  isPinned: boolean;
-  commentCount: number;
-  viewCount: number;
-  createdAt: string;
-  categoryName: string;
-}
-
-function toDisplayPost(post: ForumPost): DisplayPost {
+function mapPopularToCategory(raw: PopularForum): ForumHubCategory {
   return {
-    id: post.id,
-    title: post.title,
-    slug: post.slug,
-    type: normalizePostType(post.type),
-    authorName: getAuthorName(post),
-    isPinned: post.isPinned,
-    commentCount: post.commentCount || 0,
-    viewCount: post.viewCount || 0,
-    createdAt: post.createdAt,
-    categoryName: post.category?.name || '',
+    id: raw.id,
+    name: raw.name,
+    description: raw.description,
+    iconUrl: raw.iconUrl,
+    color: raw.color,
+    postCount: raw.postCount ?? 0,
   };
 }
 
-function getForumIcon(category: ForumCategory): string {
-  if (category.iconUrl) return '';
-  if (category.iconEmoji) return category.iconEmoji;
-  return FALLBACK_ICONS[category.name] || DEFAULT_FORUM_ICON;
+function mapCategory(raw: ForumCategory): ForumHubCategory {
+  return {
+    id: raw.id,
+    name: raw.name,
+    description: raw.description,
+    iconEmoji: raw.iconEmoji,
+    iconUrl: raw.iconUrl,
+    color: raw.color,
+    postCount: raw.postCount ?? 0,
+    isPinned: raw.isPinned,
+  };
 }
 
-/** Activity signal per category */
-interface CategoryActivity {
-  postCount7d: number;
-  commentSum7d: number;
-  latestPostTitle?: string;
-  latestPostDate?: string;
+function mapPost(raw: ForumPost): ForumHubPost {
+  return {
+    id: raw.id,
+    title: raw.title,
+    authorName: getAuthorName(raw),
+    viewCount: raw.viewCount ?? 0,
+    commentCount: raw.commentCount ?? 0,
+    createdAt: raw.createdAt,
+    isPinned: raw.isPinned,
+  };
 }
-
-function getActivityBadge(activity?: CategoryActivity): { label: string; className: string } | null {
-  if (!activity?.latestPostDate) return null;
-  const diff = Date.now() - new Date(activity.latestPostDate).getTime();
-  const hours = diff / (1000 * 60 * 60);
-  if (hours <= 24) return { label: '오늘 글 있음', className: 'bg-blue-500 text-white' };
-  if (hours <= 168) return { label: '최근 활동', className: 'bg-slate-100 text-slate-600' };
-  return null;
-}
-
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diff = now.getTime() - date.getTime();
-  const hours = Math.floor(diff / (1000 * 60 * 60));
-
-  if (hours < 1) return '방금 전';
-  if (hours < 24) return `${hours}시간 전`;
-  if (hours < 48) return '어제';
-  return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
-}
-
-// ============================================================================
-// Sub-components
-// ============================================================================
-
-/** Forum Icon — iconUrl 이미지 또는 이모지 fallback (항상 표시 보장) */
-function ForumIcon({ category, size = 48 }: { category: ForumCategory; size?: number }) {
-  const emoji = getForumIcon(category);
-
-  if (category.iconUrl) {
-    return (
-      <img
-        src={category.iconUrl}
-        alt={category.name}
-        className="rounded-xl object-cover flex-shrink-0"
-        style={{ width: size, height: size }}
-      />
-    );
-  }
-
-  return (
-    <div
-      className="rounded-xl flex items-center justify-center flex-shrink-0"
-      style={{
-        width: size,
-        height: size,
-        backgroundColor: category.color ? `${category.color}18` : '#f0f9ff',
-        fontSize: size * 0.5,
-      }}
-    >
-      {emoji}
-    </div>
-  );
-}
-
-/** Hero Header — 포럼 아이덴티티 */
-function HeroHeader({ title, description }: { title: string; description: string }) {
-  return (
-    <header className="bg-white border-b border-slate-200">
-      <PageContainer>
-        <div className="py-8">
-          <h1 className="text-2xl font-bold text-slate-900">{title}</h1>
-          <p className="mt-1.5 text-sm text-slate-500">{description}</p>
-        </div>
-      </PageContainer>
-    </header>
-  );
-}
-
-/** Forum Card Grid — 카테고리 카드 (다음 카페 스타일 핵심 UI) + 활동 신호 */
-function ForumCardGrid({ categories, basePath, activityMap }: { categories: ForumCategory[]; basePath: string; activityMap: Record<string, CategoryActivity> }) {
-  if (categories.length === 0) {
-    return (
-      <section className="py-8">
-        <div className="text-center py-12 bg-white rounded-xl border border-slate-200">
-          <div className="text-4xl mb-3">📂</div>
-          <p className="text-slate-500 mb-1">등록된 포럼이 없습니다</p>
-          <p className="text-sm text-slate-400">운영자가 포럼을 개설하면 여기에 표시됩니다</p>
-        </div>
-      </section>
-    );
-  }
-
-  return (
-    <section className="py-6">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-bold text-slate-900">포럼 목록</h2>
-        <span className="text-sm text-slate-400">{categories.length}개 포럼</span>
-      </div>
-      <div className="bg-white rounded-xl border border-slate-200 overflow-hidden divide-y divide-slate-100">
-        {categories.map((cat) => {
-          const activity = activityMap[cat.id];
-          const badge = getActivityBadge(activity);
-          return (
-            <Link
-              key={cat.id}
-              to={`${basePath}?category=${cat.id}`}
-              className="flex items-center gap-4 px-5 py-4 hover:bg-slate-50 transition-colors group"
-            >
-              <ForumIcon category={cat} size={52} />
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <h3 className="text-[15px] font-semibold text-slate-800 group-hover:text-blue-600 transition-colors">
-                    {cat.name}
-                  </h3>
-                  {cat.isPinned && (
-                    <span className="text-[10px] font-medium text-blue-600 bg-blue-50 px-1.5 py-0.5 rounded">
-                      추천
-                    </span>
-                  )}
-                  {badge && (
-                    <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${badge.className}`}>
-                      {badge.label}
-                    </span>
-                  )}
-                </div>
-                {cat.description && (
-                  <p className="mt-0.5 text-xs text-slate-400 truncate">{cat.description}</p>
-                )}
-                {activity?.latestPostTitle && (
-                  <p className="mt-0.5 text-xs text-slate-500 truncate">
-                    최근: {activity.latestPostTitle}
-                  </p>
-                )}
-                <div className="flex items-center gap-3 mt-1.5">
-                  <span className="text-[11px] text-slate-400">
-                    글 {cat.postCount ?? 0}개
-                  </span>
-                  {activity && activity.postCount7d > 0 && (
-                    <span className="text-[11px] text-blue-500">
-                      이번 주 글 {activity.postCount7d}{activity.commentSum7d > 0 ? ` · 댓글 ${activity.commentSum7d}` : ''}
-                    </span>
-                  )}
-                </div>
-              </div>
-              <svg className="w-5 h-5 text-slate-300 group-hover:text-blue-400 transition-colors flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </Link>
-          );
-        })}
-      </div>
-    </section>
-  );
-}
-
-/** 게시글 아이템 */
-function PostItem({ post, basePath }: { post: DisplayPost; basePath: string }) {
-  return (
-    <li className="py-2.5 border-b border-slate-50 last:border-b-0">
-      <Link to={`${basePath}/post/${post.slug}`} className="block group">
-        <div className="flex items-center gap-1.5">
-          {post.isPinned && (
-            <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold bg-red-500 text-white">
-              공지
-            </span>
-          )}
-          <span className="text-sm text-slate-700 group-hover:text-blue-600 transition-colors truncate">
-            {post.title}
-          </span>
-          {post.commentCount > 0 && (
-            <span className="text-xs text-blue-500 font-medium flex-shrink-0">
-              [{post.commentCount}]
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-1 mt-1 text-xs text-slate-400">
-          <span>{post.authorName}</span>
-          <span className="text-slate-300">·</span>
-          <span>{formatDate(post.createdAt)}</span>
-          <span className="text-slate-300">·</span>
-          <span>조회 {post.viewCount}</span>
-        </div>
-      </Link>
-    </li>
-  );
-}
-
-/** 최근 활동 섹션 — 2열 그리드 */
-function ActivitySection({ basePath }: { basePath: string }) {
-  const [recentPosts, setRecentPosts] = useState<DisplayPost[]>([]);
-  const [popularPosts, setPopularPosts] = useState<DisplayPost[]>([]);
-
-  useEffect(() => {
-    fetchForumPosts({ limit: 5, sortBy: 'latest' })
-      .then((res) => {
-        if (res.data) setRecentPosts(res.data.map(toDisplayPost));
-      })
-      .catch(() => {});
-
-    fetchForumPosts({ limit: 5, sortBy: 'popular' })
-      .then((res) => {
-        if (res.data) {
-          const sorted = [...res.data]
-            .map(toDisplayPost)
-            .sort((a, b) => b.viewCount - a.viewCount);
-          setPopularPosts(sorted);
-        }
-      })
-      .catch(() => {});
-  }, []);
-
-  const hasContent = recentPosts.length > 0 || popularPosts.length > 0;
-  if (!hasContent) return null;
-
-  return (
-    <section className="py-6">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {/* 인기 글 */}
-        <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-3 border-b border-slate-100">
-            <h3 className="text-sm font-bold text-slate-800">인기 글</h3>
-            <Link to={`${basePath}?sort=popular`} className="text-xs text-slate-400 hover:text-blue-600">
-              더보기 →
-            </Link>
-          </div>
-          <div className="px-5 py-2">
-            {popularPosts.length === 0 ? (
-              <p className="py-6 text-center text-sm text-slate-400">
-                아직 게시글이 없습니다
-              </p>
-            ) : (
-              <ul className="list-none m-0 p-0">
-                {popularPosts.map((post) => (
-                  <PostItem key={`popular-${post.id}`} post={post} basePath={basePath} />
-                ))}
-              </ul>
-            )}
-          </div>
-        </div>
-
-        {/* 최근 글 */}
-        <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-3 border-b border-slate-100">
-            <h3 className="text-sm font-bold text-slate-800">최근 글</h3>
-            <Link to={`${basePath}?sort=latest`} className="text-xs text-slate-400 hover:text-blue-600">
-              더보기 →
-            </Link>
-          </div>
-          <div className="px-5 py-2">
-            {recentPosts.length === 0 ? (
-              <p className="py-6 text-center text-sm text-slate-400">
-                아직 게시글이 없습니다
-              </p>
-            ) : (
-              <ul className="list-none m-0 p-0">
-                {recentPosts.map((post) => (
-                  <PostItem key={post.id} post={post} basePath={basePath} />
-                ))}
-              </ul>
-            )}
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/** 글쓰기 유도 CTA */
-function WritePrompt({ basePath }: { basePath: string }) {
-  const { isAuthenticated } = useAuth();
-
-  return (
-    <section className="py-6">
-      <div className="flex items-center justify-between p-5 bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl border border-blue-100">
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-lg bg-blue-100 flex items-center justify-center text-xl">
-            ✏️
-          </div>
-          <div>
-            <h3 className="text-sm font-bold text-slate-800">포럼에 참여해 보세요</h3>
-            <p className="mt-0.5 text-xs text-slate-500">
-              {isAuthenticated
-                ? '의견, 질문, 피드백을 자유롭게 나눠보세요'
-                : '로그인 후 토론에 참여할 수 있습니다'}
-            </p>
-          </div>
-        </div>
-        {isAuthenticated ? (
-          <Link
-            to={basePath}
-            className="px-5 py-2.5 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors whitespace-nowrap"
-          >
-            포럼 보기
-          </Link>
-        ) : (
-          <Link
-            to="/workspace"
-            className="px-5 py-2.5 text-sm font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors whitespace-nowrap"
-          >
-            로그인
-          </Link>
-        )}
-      </div>
-    </section>
-  );
-}
-
-/** 이용안내 */
-function InfoSection({ basePath }: { basePath: string }) {
-  return (
-    <section className="py-4 border-t border-slate-200">
-      <div className="flex flex-wrap gap-2">
-        <Link to={`${basePath}?sort=popular`} className="text-xs text-slate-400 hover:text-blue-600 px-3 py-1.5 rounded-lg bg-slate-50 hover:bg-blue-50 transition-colors">
-          인기 글
-        </Link>
-        <Link to={`${basePath}?type=announcement`} className="text-xs text-slate-400 hover:text-blue-600 px-3 py-1.5 rounded-lg bg-slate-50 hover:bg-blue-50 transition-colors">
-          공지사항
-        </Link>
-      </div>
-    </section>
-  );
-}
-
-// ============================================================================
-// Main Component
-// ============================================================================
 
 export default function ForumHubPage({
-  title = 'o4o · 네뚜레 포럼',
+  title = '네뚜레 포럼',
   description = 'o4o 개념과 네뚜레 구조에 대한 질문과 의견을 나누는 공간입니다',
   basePath = '/forum',
 }: ForumHubPageProps) {
-  const [categories, setCategories] = useState<ForumCategory[]>([]);
-  const [activityMap, setActivityMap] = useState<Record<string, CategoryActivity>>({});
+  const { isAuthenticated } = useAuth();
 
-  useEffect(() => {
-    fetchForumCategories()
-      .then((res) => {
-        if (res.success && res.data) setCategories(res.data);
-      })
-      .catch(() => {});
+  const config: ForumHubConfig = useMemo(() => ({
+    serviceKey: 'neture',
+    heroTitle: title,
+    heroDesc: description,
+    categoryPath: (id) => `${basePath}/posts?category=${id}`,
+    listPath: `${basePath}/posts`,
 
-    // Fetch 7d stats from popular forums endpoint
-    fetchPopularForums(50)
-      .then((res) => {
-        if (res.success && res.data) {
-          const map: Record<string, CategoryActivity> = {};
-          res.data.forEach((f: PopularForum) => {
-            map[f.id] = {
-              postCount7d: f.postCount7d,
-              commentSum7d: f.commentSum7d,
-            };
-          });
-          setActivityMap((prev) => {
-            const merged = { ...prev };
-            Object.keys(map).forEach((id) => {
-              merged[id] = { ...merged[id], ...map[id] };
-            });
-            return merged;
-          });
-        }
-      })
-      .catch(() => {});
+    fetchCategories: async () => {
+      const popular = await fetchPopularForums(20);
+      if (popular.success && popular.data.length > 0) {
+        return popular.data.map(mapPopularToCategory);
+      }
+      const cats = await fetchForumCategories();
+      return (cats.data ?? []).map(mapCategory);
+    },
 
-    // Fetch recent posts for latest post preview per category
-    fetchForumPosts({ limit: 30, sortBy: 'latest' })
-      .then((res) => {
-        if (res.data) {
-          const latestByCategory: Record<string, { title: string; date: string }> = {};
-          res.data.forEach((post) => {
-            const catId = post.categoryId || post.category?.id;
-            if (catId && !latestByCategory[catId]) {
-              latestByCategory[catId] = { title: post.title, date: post.createdAt };
-            }
-          });
-          setActivityMap((prev) => {
-            const merged = { ...prev };
-            Object.entries(latestByCategory).forEach(([id, info]) => {
-              merged[id] = {
-                ...merged[id],
-                postCount7d: merged[id]?.postCount7d ?? 0,
-                commentSum7d: merged[id]?.commentSum7d ?? 0,
-                latestPostTitle: info.title,
-                latestPostDate: info.date,
-              };
-            });
-            return merged;
-          });
-        }
-      })
-      .catch(() => {});
-  }, []);
+    fetchRecentPosts: async () => {
+      const res = await fetchForumPosts({ limit: 10, sortBy: 'latest' });
+      return (res.data ?? []).map(mapPost);
+    },
 
-  return (
-    <div className="bg-slate-50 min-h-[calc(100vh-200px)]">
-      <PageHero>
-        <HeroHeader title={title} description={description} />
-      </PageHero>
+    writePrompt: { ctaPath: `${basePath}/posts` },
 
-      <PageSection>
-        <PageContainer>
-          <ForumCardGrid categories={categories} basePath={basePath} activityMap={activityMap} />
-        </PageContainer>
-      </PageSection>
+    infoLinks: [
+      { label: '인기 글', href: `${basePath}/posts?sort=popular` },
+      { label: '공지사항', href: `${basePath}/posts?type=announcement` },
+    ],
+  }), [title, description, basePath]);
 
-      <PageSection>
-        <PageContainer>
-          <ActivitySection basePath={basePath} />
-        </PageContainer>
-      </PageSection>
-
-      <PageSection>
-        <PageContainer>
-          <WritePrompt basePath={basePath} />
-        </PageContainer>
-      </PageSection>
-
-      <PageSection last>
-        <PageContainer>
-          <InfoSection basePath={basePath} />
-        </PageContainer>
-      </PageSection>
-    </div>
-  );
+  return <ForumHubTemplate config={config} isAuthenticated={isAuthenticated} />;
 }
 
 export { ForumHubPage };

--- a/services/web-neture/src/pages/library/ContentLibraryPage.tsx
+++ b/services/web-neture/src/pages/library/ContentLibraryPage.tsx
@@ -1,283 +1,202 @@
 /**
  * ContentLibraryPage — Neture 콘텐츠 라이브러리
  *
- * WO-O4O-CONTENT-FRONTEND-ACTIVATION-V1
+ * WO-NETURE-COMMUNITY-HUB-TEMPLATE-ADOPTION-V1
  *
+ * ContentHubTemplate + Neture config-only adapter.
  * Route: /content
- * API: GET /api/v1/hub/contents?serviceKey=neture&sourceDomain=cms
+ * API: GET /api/v1/hub/contents?serviceKey=neture&sourceDomain=cms&type=...
  */
 
-import { useState, useEffect, useCallback } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { ArrowLeft, FileText, ExternalLink, Image as ImageIcon, Download, Check, Loader2 } from 'lucide-react';
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, ExternalLink, Image as ImageIcon } from 'lucide-react';
+import {
+  ContentHubTemplate,
+  type ContentHubConfig,
+  type ContentHubItem,
+  type ContentHubItemContext,
+} from '@o4o/shared-space-ui';
 import { hubContentApi } from '../../lib/api/hubContent';
 import { dashboardCopyApi } from '../../lib/api/dashboardCopy';
 import { useAuth } from '../../contexts/AuthContext';
 import type { HubContentItemResponse } from '@o4o/types/hub-content';
 
-const TYPE_FILTERS = [
-  { key: 'all', label: '전체' },
-  { key: 'notice', label: '공지' },
-  { key: 'guide', label: '가이드' },
-  { key: 'knowledge', label: '지식' },
-  { key: 'promo', label: '프로모션' },
-  { key: 'news', label: '뉴스' },
-] as const;
+function apiItemToContentHubItem(item: HubContentItemResponse): ContentHubItem {
+  return {
+    id: item.id,
+    title: item.title,
+    summary: item.description,
+    thumbnail: item.thumbnailUrl || item.imageUrl,
+    href: item.linkUrl,
+    type: item.cmsType,
+    date: item.createdAt
+      ? new Date(item.createdAt).toLocaleDateString('ko-KR', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        })
+      : null,
+    isPinned: item.isPinned,
+  };
+}
 
-const PAGE_SIZE = 12;
+function CardGrid({ items, ctx }: { items: ContentHubItem[]; ctx: ContentHubItemContext }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {items.map((item) => {
+        const isCopied = ctx.copiedIds.has(item.id);
+        const isCopying = ctx.copyingId === item.id;
+        const hasLink = !!item.href;
+        return (
+          <div
+            key={item.id}
+            onClick={() => item.href && window.open(item.href, '_blank', 'noopener')}
+            className={`bg-white rounded-lg border border-gray-200 overflow-hidden transition-all ${
+              hasLink ? 'cursor-pointer hover:shadow-md hover:border-primary-200' : 'opacity-80'
+            }`}
+          >
+            {item.thumbnail ? (
+              <div className="aspect-[16/9] bg-gray-100 overflow-hidden">
+                <img
+                  src={item.thumbnail}
+                  alt={item.title}
+                  className="w-full h-full object-cover"
+                  onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                />
+              </div>
+            ) : (
+              <div className="aspect-[16/9] bg-gray-50 flex items-center justify-center">
+                <ImageIcon className="w-8 h-8 text-gray-200" />
+              </div>
+            )}
+            <div className="p-4">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5 mb-1.5">
+                    {item.type && (
+                      <span className="inline-block px-2 py-0.5 text-[10px] font-medium bg-gray-100 text-gray-500 rounded">
+                        {item.type}
+                      </span>
+                    )}
+                    {item.isPinned && (
+                      <span className="inline-block px-2 py-0.5 text-[10px] font-medium bg-primary-50 text-primary-600 rounded">
+                        추천
+                      </span>
+                    )}
+                  </div>
+                  <h3 className="text-sm font-semibold text-gray-800 line-clamp-2">
+                    {item.title}
+                  </h3>
+                  {item.summary && (
+                    <p className="text-xs text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
+                  )}
+                </div>
+                {hasLink && (
+                  <ExternalLink className="w-3.5 h-3.5 text-gray-300 shrink-0 mt-0.5" />
+                )}
+              </div>
+              <div className="flex items-center justify-between mt-2">
+                <p className="text-[10px] text-gray-400">{item.date}</p>
+                <button
+                  onClick={(e) => { e.stopPropagation(); ctx.onCopy(item); }}
+                  disabled={isCopied || isCopying}
+                  className={`inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded transition-colors ${
+                    isCopied
+                      ? 'bg-gray-100 text-gray-400 cursor-default'
+                      : isCopying
+                        ? 'bg-gray-100 text-gray-400 cursor-wait'
+                        : 'bg-primary-50 text-primary-600 hover:bg-primary-100'
+                  }`}
+                >
+                  {isCopied ? ctx.copiedLabel : isCopying ? ctx.copyingLabel : ctx.copyLabel}
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
 export default function ContentLibraryPage() {
   const { user } = useAuth();
-  const navigate = useNavigate();
-  const [items, setItems] = useState<HubContentItemResponse[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [activeType, setActiveType] = useState('all');
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const [total, setTotal] = useState(0);
-  const [copiedIds, setCopiedIds] = useState<Set<string>>(new Set());
-  const [copyingId, setCopyingId] = useState<string | null>(null);
+  const userId = user?.id;
 
-  useEffect(() => {
-    if (!user?.id) return;
-    dashboardCopyApi.getCopiedSourceIds(user.id)
-      .then(ids => setCopiedIds(new Set(ids)))
-      .catch(() => {});
-  }, [user?.id]);
+  const config: ContentHubConfig = useMemo(() => ({
+    serviceKey: 'neture',
+    heroTitle: '콘텐츠 라이브러리',
+    heroDesc: 'Neture 콘텐츠를 한눈에 확인하세요',
+    headerAction: (
+      <Link
+        to="/"
+        className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 no-underline"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Home
+      </Link>
+    ),
 
-  const handleCopy = async (e: React.MouseEvent, item: HubContentItemResponse) => {
-    e.stopPropagation();
-    if (!user?.id || copyingId) return;
-    setCopyingId(item.id);
-    try {
-      await dashboardCopyApi.copyAsset({
-        sourceType: 'hub_content',
-        sourceId: item.id,
-        targetDashboardId: user.id,
-      });
-      setCopiedIds(prev => new Set(prev).add(item.id));
-      if (confirm('내 콘텐츠에 복사되었습니다.\n내 콘텐츠로 이동하시겠습니까?')) {
-        navigate('/my-content');
+    showSearch: false,
+    filters: [
+      { key: 'all', label: '전체' },
+      { key: 'notice', label: '공지' },
+      { key: 'guide', label: '가이드' },
+      { key: 'knowledge', label: '지식' },
+      { key: 'promo', label: '프로모션' },
+      { key: 'news', label: '뉴스' },
+    ],
+    pageLimit: 12,
+
+    fetchItems: async ({ filter, page, limit }) => {
+      try {
+        const res = await hubContentApi.list({
+          sourceDomain: 'cms',
+          type: filter !== 'all' ? filter : undefined,
+          page,
+          limit,
+        });
+        return {
+          items: (res?.data ?? []).map(apiItemToContentHubItem),
+          total: res?.pagination?.total ?? 0,
+        };
+      } catch {
+        return { items: [], total: 0 };
       }
-    } catch (err: any) {
-      alert(err.message || '복사 중 오류가 발생했습니다.');
-    } finally {
-      setCopyingId(null);
-    }
-  };
+    },
 
-  const fetchContents = useCallback(async (p: number) => {
-    setLoading(true);
-    try {
-      const res = await hubContentApi.list({
-        sourceDomain: 'cms',
-        page: p,
-        limit: PAGE_SIZE,
-      });
-      const list = Array.isArray(res?.data) ? res.data : [];
-      setItems(list);
-      setTotalPages(res?.pagination?.totalPages ?? 1);
-      setTotal(res?.pagination?.total ?? list.length);
-    } catch {
-      setItems([]);
-      setTotalPages(1);
-      setTotal(0);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+    loadCopiedIds: userId
+      ? async () => {
+          try {
+            const ids = await dashboardCopyApi.getCopiedSourceIds(userId);
+            return new Set(ids);
+          } catch {
+            return new Set<string>();
+          }
+        }
+      : undefined,
 
-  useEffect(() => {
-    fetchContents(page);
-  }, [page, fetchContents]);
+    onCopy: userId
+      ? async (item: ContentHubItem) => {
+          await dashboardCopyApi.copyAsset({
+            sourceType: 'hub_content',
+            sourceId: item.id,
+            targetDashboardId: userId,
+          });
+        }
+      : undefined,
 
-  const handleTypeChange = (type: string) => {
-    setActiveType(type);
-    setPage(1);
-  };
+    copyLabel: '↓ 내 콘텐츠로',
+    copiedLabel: '✓ 가져옴',
+    copyingLabel: '복사 중...',
+    afterCopyAction: { label: '내 콘텐츠로', href: '/my-content' },
 
-  const handleItemClick = (item: HubContentItemResponse) => {
-    if (item.linkUrl) {
-      window.open(item.linkUrl, '_blank', 'noopener');
-    }
-  };
+    renderItems: (items, ctx) => <CardGrid items={items} ctx={ctx} />,
 
-  const formatDate = (dateStr: string) => {
-    try {
-      return new Date(dateStr).toLocaleDateString('ko-KR', {
-        year: 'numeric', month: 'short', day: 'numeric',
-      });
-    } catch {
-      return '';
-    }
-  };
+    emptyMessage: '등록된 콘텐츠가 없습니다.',
+    emptyFilteredMessage: '조건에 맞는 콘텐츠가 없습니다.',
+  }), [userId]);
 
-  // Client-side type filter
-  const filteredItems = activeType === 'all'
-    ? items
-    : items.filter(item => item.cmsType === activeType);
-
-  return (
-    <div className="max-w-4xl mx-auto px-4 py-8">
-      {/* Header */}
-      <div className="mb-6">
-        <Link
-          to="/"
-          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-3"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          Home
-        </Link>
-        <h1 className="text-xl font-bold text-gray-900">콘텐츠 라이브러리</h1>
-        <p className="text-sm text-gray-500 mt-1">
-          Neture 콘텐츠를 한눈에 확인하세요
-        </p>
-      </div>
-
-      {/* Type Filter */}
-      <div className="flex flex-wrap gap-2 mb-6">
-        {TYPE_FILTERS.map((f) => (
-          <button
-            key={f.key}
-            onClick={() => handleTypeChange(f.key)}
-            className={`px-3 py-1.5 text-xs font-medium rounded-full transition-colors ${
-              activeType === f.key
-                ? 'bg-primary-600 text-white'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-            }`}
-          >
-            {f.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Result count */}
-      {!loading && total > 0 && (
-        <p className="text-xs text-gray-400 mb-4">{total}개의 콘텐츠</p>
-      )}
-
-      {/* Content List */}
-      {loading ? (
-        <div className="flex items-center justify-center py-20">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600" />
-        </div>
-      ) : filteredItems.length === 0 ? (
-        <div className="text-center py-20">
-          <FileText className="w-10 h-10 text-gray-300 mx-auto mb-3" />
-          <p className="text-sm text-gray-400">등록된 콘텐츠가 없습니다.</p>
-        </div>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {filteredItems.map((item) => {
-            const hasLink = !!item.linkUrl;
-            const img = item.thumbnailUrl || item.imageUrl || null;
-            return (
-              <div
-                key={item.id}
-                onClick={() => handleItemClick(item)}
-                className={`bg-white rounded-lg border border-gray-200 overflow-hidden transition-all ${
-                  hasLink
-                    ? 'cursor-pointer hover:shadow-md hover:border-primary-200'
-                    : 'opacity-80'
-                }`}
-              >
-                {img ? (
-                  <div className="aspect-[16/9] bg-gray-100 overflow-hidden">
-                    <img
-                      src={img}
-                      alt={item.title}
-                      className="w-full h-full object-cover"
-                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                    />
-                  </div>
-                ) : (
-                  <div className="aspect-[16/9] bg-gray-50 flex items-center justify-center">
-                    <ImageIcon className="w-8 h-8 text-gray-200" />
-                  </div>
-                )}
-                <div className="p-4">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-1.5 mb-1.5">
-                        {item.cmsType && (
-                          <span className="inline-block px-2 py-0.5 text-[10px] font-medium bg-gray-100 text-gray-500 rounded">
-                            {item.cmsType}
-                          </span>
-                        )}
-                        {item.isPinned && (
-                          <span className="inline-block px-2 py-0.5 text-[10px] font-medium bg-primary-50 text-primary-600 rounded">
-                            추천
-                          </span>
-                        )}
-                      </div>
-                      <h3 className="text-sm font-semibold text-gray-800 line-clamp-2">
-                        {item.title}
-                      </h3>
-                      {item.description && (
-                        <p className="text-xs text-gray-500 mt-1 line-clamp-2">
-                          {item.description}
-                        </p>
-                      )}
-                    </div>
-                    {hasLink && (
-                      <ExternalLink className="w-3.5 h-3.5 text-gray-300 shrink-0 mt-0.5" />
-                    )}
-                  </div>
-                  <div className="flex items-center justify-between mt-2">
-                    <p className="text-[10px] text-gray-400">
-                      {formatDate(item.createdAt)}
-                    </p>
-                    {user && (
-                      <button
-                        onClick={(e) => handleCopy(e, item)}
-                        disabled={copiedIds.has(item.id) || copyingId === item.id}
-                        className={`inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded transition-colors ${
-                          copiedIds.has(item.id)
-                            ? 'bg-gray-100 text-gray-400 cursor-default'
-                            : copyingId === item.id
-                              ? 'bg-gray-100 text-gray-400 cursor-wait'
-                              : 'bg-primary-50 text-primary-600 hover:bg-primary-100'
-                        }`}
-                      >
-                        {copiedIds.has(item.id) ? (
-                          <><Check className="w-3 h-3" /> 가져옴</>
-                        ) : copyingId === item.id ? (
-                          <><Loader2 className="w-3 h-3 animate-spin" /> 복사 중</>
-                        ) : (
-                          <><Download className="w-3 h-3" /> 내 콘텐츠로</>
-                        )}
-                      </button>
-                    )}
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-2 mt-8">
-          <button
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-            disabled={page <= 1}
-            className="px-3 py-1.5 text-xs font-medium border border-gray-200 rounded-lg disabled:opacity-40 hover:bg-gray-50 transition-colors"
-          >
-            이전
-          </button>
-          <span className="text-xs text-gray-500">
-            {page} / {totalPages}
-          </span>
-          <button
-            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-            disabled={page >= totalPages}
-            className="px-3 py-1.5 text-xs font-medium border border-gray-200 rounded-lg disabled:opacity-40 hover:bg-gray-50 transition-colors"
-          >
-            다음
-          </button>
-        </div>
-      )}
-    </div>
-  );
+  return <ContentHubTemplate config={config} />;
 }

--- a/services/web-neture/src/pages/resources/NetureResourcesPage.tsx
+++ b/services/web-neture/src/pages/resources/NetureResourcesPage.tsx
@@ -1,171 +1,86 @@
 /**
  * NetureResourcesPage — Neture 자료실
  *
+ * WO-NETURE-COMMUNITY-HUB-TEMPLATE-ADOPTION-V1
+ *
+ * ResourcesHubTemplate + Neture adapter (read-only).
  * Route: /resources
  * API: GET /api/v1/neture/content?type=resource
- *
- * CMS type='resource' 콘텐츠를 목록으로 표시한다.
- * 공개 접근 (인증 불필요)
+ * 등록/삭제/관리 기능 없음 — 공개 읽기 전용.
  */
 
-import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
-import { ArrowLeft, FolderOpen, Paperclip, ExternalLink, ArrowRight } from 'lucide-react';
-import { PageContainer } from '@o4o/ui';
+import { useMemo } from 'react';
+import {
+  ResourcesHubTemplate,
+  type ResourcesHubConfig,
+  type ResourcesHubItem,
+} from '@o4o/shared-space-ui';
 import { cmsApi, type CmsContent } from '../../lib/api/content';
 
-const PAGE_SIZE = 12;
+function mapCmsToResource(c: CmsContent): ResourcesHubItem {
+  const firstAtt = c.attachments?.[0];
+  let source_type = 'view';
+  let source_url: string | null = null;
+  let source_file_name: string | null = null;
 
-function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('ko-KR');
+  if (firstAtt) {
+    source_type = 'file';
+    source_url = firstAtt.url;
+    source_file_name = firstAtt.name;
+  } else if (c.linkUrl) {
+    source_type = 'external';
+    source_url = c.linkUrl;
+  }
+
+  return {
+    id: c.id,
+    title: c.title,
+    summary: c.summary,
+    body: c.body,
+    source_type,
+    source_url,
+    source_file_name,
+    view_count: c.viewCount ?? 0,
+    author_name: null,
+    created_at: c.publishedAt || c.createdAt,
+    like_count: c.recommendCount,
+    isRecommendedByMe: c.isRecommendedByMe,
+  };
+}
+
+function useNetureResourcesConfig(): ResourcesHubConfig {
+  return useMemo(() => ({
+    serviceKey: 'neture',
+    tableId: 'neture-resources',
+
+    heroTitle: '자료실',
+    heroDesc: '공급자·파트너를 위한 공유 자료 모음입니다.',
+    searchPlaceholder: '자료를 검색하세요',
+
+    pageLimit: 12,
+
+    fetchItems: async ({ page, limit }) => {
+      const res = await cmsApi.getContents({ type: 'resource', sort: 'latest', page, limit });
+      return {
+        items: (res.data ?? []).map(mapCmsToResource),
+        total: res.pagination?.total ?? 0,
+        totalPages: res.pagination?.totalPages ?? 1,
+      };
+    },
+
+    fetchDetail: async (id) => {
+      const c = await cmsApi.getContentById(id);
+      return mapCmsToResource(c);
+    },
+
+    trackView: (id) => { cmsApi.trackView(id).catch(() => {}); },
+
+    emptyMessage: '등록된 자료가 없습니다.',
+    emptyFilteredMessage: '검색 결과가 없습니다.',
+  }), []);
 }
 
 export default function NetureResourcesPage() {
-  const [items, setItems] = useState<CmsContent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-
-  useEffect(() => {
-    setLoading(true);
-    cmsApi
-      .getContents({ type: 'resource', sort: 'latest', page, limit: PAGE_SIZE })
-      .then((res) => {
-        setItems(res.data);
-        setTotalPages(res.pagination.totalPages || 1);
-      })
-      .finally(() => setLoading(false));
-  }, [page]);
-
-  return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Hero */}
-      <section className="bg-gradient-to-br from-primary-600 to-primary-800 text-white py-12">
-        <PageContainer>
-          <Link
-            to="/"
-            className="inline-flex items-center text-white/70 hover:text-white text-sm mb-6"
-          >
-            <ArrowLeft className="w-4 h-4 mr-1" />
-            Home
-          </Link>
-          <h1 className="text-2xl font-bold mb-2">자료실</h1>
-          <p className="text-white/80 text-sm">공급자·파트너를 위한 공유 자료 모음입니다.</p>
-        </PageContainer>
-      </section>
-
-      {/* List */}
-      <section className="py-10">
-        <PageContainer>
-          {loading ? (
-            <div className="space-y-3">
-              {[1, 2, 3, 4].map((i) => (
-                <div key={i} className="h-20 bg-white rounded-xl border border-gray-200 animate-pulse" />
-              ))}
-            </div>
-          ) : items.length === 0 ? (
-            <div className="py-24 text-center">
-              <FolderOpen className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-              <p className="text-gray-500 font-medium">등록된 자료가 없습니다.</p>
-              <p className="text-gray-400 text-sm mt-1">준비 중인 자료가 곧 업로드됩니다.</p>
-            </div>
-          ) : (
-            <>
-              <div className="space-y-3">
-                {items.map((item) => (
-                  <div
-                    key={item.id}
-                    className="bg-white rounded-xl border border-gray-200 p-5 hover:border-primary-200 hover:shadow-sm transition-all"
-                  >
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm font-semibold text-gray-900 truncate">{item.title}</p>
-                        {item.summary && (
-                          <p className="text-xs text-gray-500 mt-1 line-clamp-2">{item.summary}</p>
-                        )}
-                        <div className="flex items-center gap-3 mt-2 text-xs text-gray-400">
-                          {item.attachments && item.attachments.length > 0 && (
-                            <span className="flex items-center gap-1">
-                              <Paperclip className="w-3 h-3" />
-                              {item.attachments.length}개 첨부
-                            </span>
-                          )}
-                          <span>{item.publishedAt ? formatDate(item.publishedAt) : ''}</span>
-                        </div>
-                      </div>
-                      {item.linkUrl && (
-                        <a
-                          href={item.linkUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="shrink-0 flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 font-medium"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <ExternalLink className="w-3.5 h-3.5" />
-                          {item.linkText || '열기'}
-                        </a>
-                      )}
-                    </div>
-                    {/* Attachments */}
-                    {item.attachments && item.attachments.length > 0 && (
-                      <div className="mt-3 pt-3 border-t border-gray-100 flex flex-wrap gap-2">
-                        {item.attachments.map((att, idx) => (
-                          <a
-                            key={idx}
-                            href={att.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-50 hover:bg-primary-50 rounded-lg text-xs text-gray-700 hover:text-primary-700 border border-gray-200 hover:border-primary-200 transition-colors"
-                          >
-                            <Paperclip className="w-3 h-3" />
-                            {att.name}
-                          </a>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-
-              {/* Pagination */}
-              {totalPages > 1 && (
-                <div className="flex items-center justify-center gap-2 mt-8">
-                  <button
-                    onClick={() => setPage((p) => Math.max(1, p - 1))}
-                    disabled={page === 1}
-                    className="px-3 py-1.5 text-sm rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    이전
-                  </button>
-                  <span className="text-sm text-gray-500">
-                    {page} / {totalPages}
-                  </span>
-                  <button
-                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                    disabled={page === totalPages}
-                    className="px-3 py-1.5 text-sm rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    다음
-                  </button>
-                </div>
-              )}
-            </>
-          )}
-        </PageContainer>
-      </section>
-
-      {/* Back to Home */}
-      <section className="py-8">
-        <PageContainer>
-          <Link
-            to="/"
-            className="inline-flex items-center gap-1 text-sm text-primary-600 hover:text-primary-700"
-          >
-            <ArrowRight className="w-4 h-4 rotate-180" />
-            Home으로 돌아가기
-          </Link>
-        </PageContainer>
-      </section>
-    </div>
-  );
+  const config = useNetureResourcesConfig();
+  return <ResourcesHubTemplate config={config} />;
 }


### PR DESCRIPTION
## Summary
Migrate Neture's three Community Hub pages from service-local implementations to shared `@o4o/shared-space-ui` Hub Templates. **Second commonization step for Neture** (first was Header unification in #169).

These 7 files are intentionally a **single inseparable unit** — pages depend on the shared-space-ui dep, App.tsx routes depend on the new pages, and the API client adds the `type` parameter that the new ContentHubTemplate requires.

## Changes (7 files, +325 / -902 net consolidation)

| File | Role |
|---|---|
| `services/web-neture/package.json` | Add `@o4o/shared-space-ui` workspace dep |
| `pnpm-lock.yaml` | Re-link for new dep (minimal churn after `pnpm install`) |
| `services/web-neture/src/App.tsx` | Drop 3 legacy `/forum` routes (now served via NetureLayout canonical routing) |
| `services/web-neture/src/lib/api/hubContent.ts` | Add `type` query param for ContentHubTemplate |
| `services/web-neture/src/pages/forum/ForumHubPage.tsx` | Replace bespoke impl with `ForumHubTemplate` adapter (basePath prop reuses for `/forum` + `/workspace/forum`) |
| `services/web-neture/src/pages/library/ContentLibraryPage.tsx` | Replace bespoke impl with `ContentHubTemplate` adapter |
| `services/web-neture/src/pages/resources/NetureResourcesPage.tsx` | Replace bespoke impl with `ResourcesHubTemplate` adapter (read-only) |

## Local verification
- ✅ `pnpm install` — clean
- ✅ `npx tsc --noEmit` (web-neture) — 0 errors
- ✅ `npm run build` (web-neture) — built in 16.24s, NetureResourcesPage / ContentLibraryPage chunks produced

## Out of scope
- Other services (only web-neture)
- Docs (already shipped in WO-O4O-COMMONIZATION-DOCS-APPLY-V1, #170)
- Notifications, LMS, etc.

## Post-merge verification plan
- [ ] CI green on this PR
- [ ] Cloud Run web-neture re-deploy
- [ ] Visual smoke: `/forum`, `/library/content`, `/resources` render via Hub Template UI
- [ ] API calls (`/api/v1/hub/contents?type=...`) succeed

## Branch lifecycle
`temp/*` short-lived. Delete immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)