### PR TITLE
fix(neture): add shared-space-ui COPY to web-neture Dockerfile (hotfix #171)

### DIFF
--- a/services/web-neture/Dockerfile
+++ b/services/web-neture/Dockerfile
@@ -34,6 +34,7 @@ COPY packages/admin-ux-core/package.json ./packages/admin-ux-core/
 COPY packages/o4o-ai-components/package.json ./packages/o4o-ai-components/
 COPY packages/error-handling/package.json ./packages/error-handling/
 COPY packages/account-ui/package.json ./packages/account-ui/
+COPY packages/shared-space-ui/package.json ./packages/shared-space-ui/
 
 # Copy service package.json
 COPY services/web-neture/package.json ./services/web-neture/
@@ -59,6 +60,7 @@ COPY packages/admin-ux-core/ ./packages/admin-ux-core/
 COPY packages/o4o-ai-components/ ./packages/o4o-ai-components/
 COPY packages/error-handling/ ./packages/error-handling/
 COPY packages/account-ui/ ./packages/account-ui/
+COPY packages/shared-space-ui/ ./packages/shared-space-ui/
 
 # Copy service source
 COPY services/web-neture/ ./services/web-neture/


### PR DESCRIPTION
## Summary
**Hotfix for #171.** The Neture Hub Template adoption added `@o4o/shared-space-ui` as a workspace dep, but `web-neture/Dockerfile` uses explicit per-package COPY and was missing the new dep, causing Cloud Run deploy to fail:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In services/web-neture:
"@o4o/shared-space-ui@workspace:*" is in the dependencies but no
package named "@o4o/shared-space-ui" is present in the workspace
```

## Change (1 file, +2 lines)
- `services/web-neture/Dockerfile` — add `shared-space-ui` to both COPY blocks (package.json then full source), matching the pattern already used by web-glycopharm / web-k-cosmetics / web-kpa-society.

## Test plan
- [ ] CI green
- [ ] Cloud Run web-neture deploy succeeds
- [ ] `/forum`, `/library/content`, `/resources` pages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)