### PR TITLE
WO-O4O-LMS-NOTIFICATION-INTEGRATION-V1

### DIFF
--- a/apps/api-server/src/entities/Notification.ts
+++ b/apps/api-server/src/entities/Notification.ts
@@ -38,6 +38,10 @@ export type NotificationType =
   | 'member.fee_overdue'
   | 'member.report_rejected'
   | 'member.education_deadline'
+  // WO-O4O-LMS-NOTIFICATION-INTEGRATION-V1: LMS course lifecycle events
+  | 'lms.course_submitted'
+  | 'lms.course_approved'
+  | 'lms.course_rejected'
   | 'custom';
 
 // Legacy interface for backward compatibility

--- a/apps/api-server/src/modules/lms/services/CourseService.ts
+++ b/apps/api-server/src/modules/lms/services/CourseService.ts
@@ -3,6 +3,7 @@ import { AppDataSource } from '../../../database/connection.js';
 import { BaseService } from '../../../common/base.service.js';
 import { Course, CourseStatus, ContentKind, CourseVisibility } from '@o4o/lms-core';
 import { sanitizeInstructor } from '../utils/sanitize-user.js';
+import { notificationService } from '../../../services/NotificationService.js';
 import logger from '../../../utils/logger.js';
 
 /** O4O Tag Policy V1 — sanitize (trim / #strip / 30char / dedup) */
@@ -344,6 +345,19 @@ export class CourseService extends BaseService<Course> {
       title: updated.title,
     });
 
+    // WO-O4O-LMS-NOTIFICATION-INTEGRATION-V1
+    await notificationService.createNotification({
+      userId: updated.instructorId,
+      organizationId: updated.organizationId,
+      type: 'lms.course_submitted',
+      title: '강의 검토 요청',
+      message: '강의가 검토 요청 상태로 변경되었습니다.',
+      metadata: {
+        courseId: updated.id,
+        courseTitle: updated.title,
+      },
+    });
+
     return updated;
   }
 
@@ -369,6 +383,19 @@ export class CourseService extends BaseService<Course> {
     logger.info(`[LMS] Course approved & published`, {
       id: updated.id,
       title: updated.title,
+    });
+
+    // WO-O4O-LMS-NOTIFICATION-INTEGRATION-V1
+    await notificationService.createNotification({
+      userId: updated.instructorId,
+      organizationId: updated.organizationId,
+      type: 'lms.course_approved',
+      title: '강의 승인 완료',
+      message: '강의가 승인되었습니다.',
+      metadata: {
+        courseId: updated.id,
+        courseTitle: updated.title,
+      },
     });
 
     return updated;
@@ -402,6 +429,20 @@ export class CourseService extends BaseService<Course> {
       id: updated.id,
       title: updated.title,
       reason: trimmed,
+    });
+
+    // WO-O4O-LMS-NOTIFICATION-INTEGRATION-V1
+    await notificationService.createNotification({
+      userId: updated.instructorId,
+      organizationId: updated.organizationId,
+      type: 'lms.course_rejected',
+      title: '강의 반려',
+      message: '강의가 반려되었습니다.',
+      metadata: {
+        courseId: updated.id,
+        courseTitle: updated.title,
+        rejectionReason: trimmed,
+      },
     });
 
     return updated;


### PR DESCRIPTION
## Summary
First connection of the LMS domain to the platform notification core (#168). The 3 course lifecycle methods now trigger in-app notifications to the instructor.

## Changes (2 files, +45 lines)

**`apps/api-server/src/entities/Notification.ts`** (+4)
Add 3 LMS event types to the `NotificationType` union following the existing `dot.lower_snake` convention:
- `lms.course_submitted`
- `lms.course_approved`
- `lms.course_rejected`

**`apps/api-server/src/modules/lms/services/CourseService.ts`** (+41)
- Import `notificationService` singleton
- `submitForReview` → notify `instructorId` with type `lms.course_submitted`
- `approveCourse` → notify `instructorId` with type `lms.course_approved`
- `rejectCourse` → notify `instructorId` with type `lms.course_rejected` (rejectionReason in metadata)

Each call forwards `organizationId` so KPA multi-branch filtering still works. `serviceKey` is omitted because the Course entity has no `serviceKey` column yet — to be added when that field exists.

## Design choices
- **No try/catch wrapper** per WO directive. NotificationService's internal try/catch absorbs SSE realtime failures; DB persistence failure correctly propagates and aborts the lifecycle action.
- **Recipient = instructorId** (the only required user FK on Course). This means the instructor receives notifications about their own course events — matches existing `logger.info` pattern that doesn't distinguish actor vs. owner.
- **Scope limited to 3 methods.** Assignment / Quiz / Live integration is a separate follow-up WO.

## Verification
- ✅ `npx tsc --noEmit` (api-server) — 0 errors

## Smoke after merge
1. Trigger `submitForReview` / `approveCourse` / `rejectCourse` via instructor-dashboard / operator-dashboard
2. Inspect `notifications` table — row should appear with `userId = instructor.id`, `type = lms.course_*`, `metadata.courseId` / `courseTitle`
3. Connected SSE clients on `/api/v1/notifications/stream` should receive the event

## Branch lifecycle
`temp/*` short-lived. Delete immediately after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)