### PR TITLE
feat(event-offer): WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1

### DIFF
--- a/apps/api-server/src/database/migrations/20260915000000-AddEventPriceToOrgProductListings.ts
+++ b/apps/api-server/src/database/migrations/20260915000000-AddEventPriceToOrgProductListings.ts
@@ -1,0 +1,35 @@
+/**
+ * WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+ *
+ * organization_product_listings 에 event_price 컬럼 추가.
+ *
+ * 의미:
+ *   - event_price: 공급자가 지정한 이벤트 전용 공급가 (별도 필드)
+ *   - 기존 price 컬럼은 supplier_product_offers.price_general 스냅샷 (변경 없음)
+ *   - 일반 공급가/소비자가는 절대 수정하지 않는다 (정책)
+ *
+ * 배경:
+ *   현재 createListing 은 spo.price_general 을 opl.price 로 단순 복사하고,
+ *   이벤트 전용 가격 입력 경로가 없었다. 본 컬럼 추가로 supplier 가
+ *   이벤트 가격을 별도 저장할 수 있게 한다. 기존 row 는 NULL.
+ */
+
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEventPriceToOrgProductListings20260915000000 implements MigrationInterface {
+  name = 'AddEventPriceToOrgProductListings20260915000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE organization_product_listings
+        ADD COLUMN IF NOT EXISTS event_price NUMERIC(12, 2) NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE organization_product_listings
+        DROP COLUMN IF EXISTS event_price
+    `);
+  }
+}

--- a/apps/api-server/src/modules/store-core/entities/organization-product-listing.entity.ts
+++ b/apps/api-server/src/modules/store-core/entities/organization-product-listing.entity.ts
@@ -95,6 +95,15 @@ export class OrganizationProductListing {
   price: number | null;
 
   /**
+   * WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+   * 이벤트 전용 공급가. supplier 가 일반 공급가와 별도로 지정.
+   * NULL 이면 이벤트 전용 가격이 설정되지 않은 (레거시) listing.
+   * 일반 공급가/소비자가는 절대 수정하지 않는다.
+   */
+  @Column({ name: 'event_price', type: 'numeric', precision: 12, scale: 2, nullable: true })
+  event_price: number | null;
+
+  /**
    * Origin type of this listing — 'market_trial' when created via Trial listing flow.
    * WO-MARKET-TRIAL-LISTING-AUTOLINK-V1
    */

--- a/apps/api-server/src/routes/kpa/controllers/event-offer.controller.ts
+++ b/apps/api-server/src/routes/kpa/controllers/event-offer.controller.ts
@@ -87,8 +87,9 @@ export function createEventOfferController(
   router.get('/enriched', optionalAuth, asyncHandler(async (req: Request, res: Response) => {
     const page = parseInt(req.query.page as string) || 1;
     const limit = Math.min(parseInt(req.query.limit as string) || 20, 50);
-    const status = (['active', 'ended', 'all'].includes(req.query.status as string)
-      ? req.query.status as 'active' | 'ended' | 'all'
+    // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 'upcoming' (시작 전) 허용
+    const status = (['upcoming', 'active', 'ended', 'all'].includes(req.query.status as string)
+      ? req.query.status as 'upcoming' | 'active' | 'ended' | 'all'
       : 'active');
 
     const { data, total } = await service.listGroupbuysEnriched(page, limit, status);

--- a/apps/api-server/src/routes/kpa/services/event-offer.service.ts
+++ b/apps/api-server/src/routes/kpa/services/event-offer.service.ts
@@ -44,37 +44,49 @@ const STORE_SERVICE_KEY_MAP: Record<string, string> = {
 
 // ─── 상태 계산 ───────────────────────────────────────────────────────────────
 
-export type EventStatusKey = 'pending' | 'approved' | 'active' | 'ended' | 'canceled';
-
 /**
- * DB 저장 status + start_at/end_at 기반 런타임 상태 계산.
- * DB 저장값: pending | approved | canceled
- * 런타임 계산값: approved(곧 시작) | active(진행중) | ended(종료)
+ * WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 'upcoming' / 'sold_out' / 'rejected' 추가.
+ * - DB 저장값: pending | approved | rejected | canceled
+ * - 런타임 계산값(approved 분기): upcoming(시작 전) | active(진행중) | sold_out(매진) | ended(종료)
  */
+export type EventStatusKey =
+  | 'pending'
+  | 'rejected'
+  | 'canceled'
+  | 'upcoming'
+  | 'active'
+  | 'sold_out'
+  | 'ended';
+
 export function resolveEventStatus(opl: {
   status: string;
   start_at: Date | string | null;
   end_at: Date | string | null;
+  total_quantity?: number | null;
 }): EventStatusKey {
   if (opl.status === 'canceled') return 'canceled';
+  if (opl.status === 'rejected') return 'rejected';
   if (opl.status === 'pending') return 'pending';
 
-  // start_at / end_at 없으면 DB 값 그대로 반환 (approved = 항상 진행)
-  if (!opl.start_at || !opl.end_at) return 'active';
-
+  // status === 'approved' 이후
   const now = new Date();
-  const startAt = opl.start_at instanceof Date ? opl.start_at : new Date(opl.start_at);
-  const endAt = opl.end_at instanceof Date ? opl.end_at : new Date(opl.end_at);
 
-  if (now < startAt) return 'approved';         // 곧 시작
-  if (now >= startAt && now <= endAt) return 'active'; // 진행중
-  return 'ended';                               // 종료
+  if (opl.start_at) {
+    const startAt = opl.start_at instanceof Date ? opl.start_at : new Date(opl.start_at);
+    if (now < startAt) return 'upcoming';
+  }
+  if (opl.end_at) {
+    const endAt = opl.end_at instanceof Date ? opl.end_at : new Date(opl.end_at);
+    if (now > endAt) return 'ended';
+  }
+  if (opl.total_quantity != null && Number(opl.total_quantity) <= 0) return 'sold_out';
+  return 'active';
 }
 
 // ─── Active 조건 SQL 절 ───────────────────────────────────────────────────────
 
 /**
- * 매장 경영자에게 노출할 이벤트 필터 조건 (테이블 alias: opl)
+ * 매장 경영자에게 노출할 "주문 가능(active)" 이벤트 필터 (테이블 alias: opl)
  * status='approved' + 날짜 조건 + 수량 조건
  */
 const ACTIVE_OFFER_CLAUSE = `
@@ -82,6 +94,18 @@ const ACTIVE_OFFER_CLAUSE = `
   AND (opl.start_at IS NULL OR NOW() >= opl.start_at)
   AND (opl.end_at   IS NULL OR NOW() <= opl.end_at)
   AND (opl.total_quantity IS NULL OR opl.total_quantity > 0)
+`.trim();
+
+/**
+ * WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+ * "곧 시작(upcoming)" 노출 조건: approved + start_at 미도래 + (end_at 미경과)
+ * — 시작 전이지만 매장 경영자에게 미리 보여주기 위한 조건. 주문은 불가.
+ */
+const UPCOMING_OFFER_CLAUSE = `
+  opl.status = 'approved'
+  AND opl.start_at IS NOT NULL
+  AND NOW() < opl.start_at
+  AND (opl.end_at IS NULL OR NOW() <= opl.end_at)
 `.trim();
 
 // ─── Service ─────────────────────────────────────────────────────────────────
@@ -138,13 +162,17 @@ export class EventOfferService {
   async listGroupbuysEnriched(
     page: number,
     limit: number,
-    status?: 'active' | 'ended' | 'all',
+    status?: 'upcoming' | 'active' | 'ended' | 'all',
     serviceKey: string = SERVICE_KEYS.KPA_GROUPBUY,
   ): Promise<{
     data: Array<{
       id: string;
       offerId: string;
       price: number | null;
+      /** WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 이벤트 전용 가격 */
+      eventPrice: number | null;
+      /** 일반 공급가 (supplier_product_offers.price_general 스냅샷) */
+      generalPrice: number | null;
       isActive: boolean;
       status: EventStatusKey;
       startAt: string | null;
@@ -152,6 +180,7 @@ export class EventOfferService {
       createdAt: string;
       updatedAt: string;
       supplierId: string;
+      /** 주문 시 적용 단가 = event_price ?? price_general */
       unitPrice: number | null;
       productName: string;
       supplierName: string;
@@ -171,11 +200,15 @@ export class EventOfferService {
     let filterClause: string;
     if (effectiveStatus === 'active') {
       filterClause = ACTIVE_OFFER_CLAUSE;
+    } else if (effectiveStatus === 'upcoming') {
+      // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 시작 전 노출
+      filterClause = UPCOMING_OFFER_CLAUSE;
     } else if (effectiveStatus === 'ended') {
-      // 취소되었거나 날짜 만료된 항목
+      // 취소되었거나 날짜 만료된 항목 + sold_out (수량 0)
       filterClause = `(
         opl.status = 'canceled'
         OR (opl.status = 'approved' AND opl.end_at IS NOT NULL AND NOW() > opl.end_at)
+        OR (opl.status = 'approved' AND opl.total_quantity IS NOT NULL AND opl.total_quantity <= 0)
       )`;
     } else {
       // 'all' — 필터 없음
@@ -195,6 +228,7 @@ export class EventOfferService {
          opl.id,
          opl.offer_id        AS "offerId",
          opl.price::numeric,
+         opl.event_price::numeric AS "eventPrice",
          opl.is_active       AS "isActive",
          opl.status          AS "dbStatus",
          opl.start_at        AS "startAt",
@@ -205,7 +239,8 @@ export class EventOfferService {
          opl.per_order_limit AS "perOrderLimit",
          opl.per_store_limit AS "perStoreLimit",
          spo.supplier_id     AS "supplierId",
-         COALESCE(spo.price_general, opl.price)::numeric AS "unitPrice",
+         spo.price_general::numeric AS "generalPrice",
+         COALESCE(opl.event_price, spo.price_general, opl.price)::numeric AS "unitPrice",
          COALESCE(pm.name, '(상품명 없음)')  AS "productName",
          COALESCE(org.name, '(공급사 없음)') AS "supplierName"
        FROM organization_product_listings opl
@@ -224,8 +259,15 @@ export class EventOfferService {
         id: r.id,
         offerId: r.offerId,
         price: r.price !== null ? Number(r.price) : null,
+        eventPrice: r.eventPrice !== null ? Number(r.eventPrice) : null,
+        generalPrice: r.generalPrice !== null ? Number(r.generalPrice) : null,
         isActive: r.isActive,
-        status: resolveEventStatus({ status: r.dbStatus, start_at: r.startAt, end_at: r.endAt }),
+        status: resolveEventStatus({
+          status: r.dbStatus,
+          start_at: r.startAt,
+          end_at: r.endAt,
+          total_quantity: r.totalQuantity,
+        }),
         startAt: r.startAt ? new Date(r.startAt).toISOString() : null,
         endAt: r.endAt ? new Date(r.endAt).toISOString() : null,
         createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : String(r.createdAt || ''),
@@ -455,9 +497,10 @@ export class EventOfferService {
     // listing은 lock 이후 재조회하므로 여기서는 supplier 정보만 가져옴
     // (supplier 정보는 별도 row라 lock 범위 밖에서 조회해도 안전)
     // → listing 먼저 찾아서 offer_id 확보
+    // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: event_price 도 동시 로드
     const preLockRows = await this.dataSource.query(
       `SELECT opl.id, opl.offer_id, opl.master_id, opl.organization_id, opl.service_key,
-              opl.status, opl.start_at, opl.end_at
+              opl.status, opl.start_at, opl.end_at, opl.event_price
        FROM organization_product_listings opl
        WHERE opl.id = $1
          AND opl.service_key = $2
@@ -488,7 +531,11 @@ export class EventOfferService {
     if (product.approval_status !== 'APPROVED') throw new EventOfferError(400, 'Product is not approved', 'PRODUCT_NOT_APPROVED');
     if (product.supplier_status !== 'ACTIVE') throw new EventOfferError(400, 'Supplier is not active', 'SUPPLIER_INACTIVE');
 
-    const unitPrice = Number(product.price_general ?? 0);
+    // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+    // 진행 중(active) 이벤트 주문 단가 = event_price (있으면) ?? price_general (레거시 fallback)
+    // 일반 공급가는 절대 변경되지 않는다 — 단가는 checkout_orders.items[].unitPrice 스냅샷에만 반영.
+    const eventPrice = preListing.event_price != null ? Number(preListing.event_price) : null;
+    const unitPrice = eventPrice ?? Number(product.price_general ?? 0);
     if (unitPrice <= 0) throw new EventOfferError(400, 'Invalid product price', 'INVALID_PRICE');
 
     // ── Step 3: 수량 제한 검증 + total_quantity 원자적 차감 ──────────────
@@ -805,6 +852,19 @@ export class EventOfferService {
      * roleType='supplier'일 땐 무시.
      */
     operatorUserId?: string;
+    /**
+     * WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+     * 이벤트 조건. supplier 가 일반 공급가/소비자가와 별도로 지정한다.
+     * 일반 공급가는 절대 변경하지 않는다.
+     */
+    eventConditions?: {
+      eventPrice: number;
+      startAt: Date;
+      endAt: Date;
+      totalQuantity?: number | null;
+      perOrderLimit?: number | null;
+      perStoreLimit?: number | null;
+    };
   }): Promise<{
     id: string;
     offerId: string;
@@ -814,6 +874,13 @@ export class EventOfferService {
     status: 'pending' | 'approved';
     isActive: boolean;
     price: number | null;
+    /** WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1 */
+    eventPrice: number | null;
+    startAt: string | null;
+    endAt: string | null;
+    totalQuantity: number | null;
+    perOrderLimit: number | null;
+    perStoreLimit: number | null;
     createdAt: string;
   }> {
     // 1. Offer 조회 (master_id, supplier_id, price, name, supplier org_name)
@@ -876,6 +943,40 @@ export class EventOfferService {
     const decidedBy = input.roleType === 'operator' ? input.operatorUserId ?? null : null;
     const decidedAt = input.roleType === 'operator' ? new Date() : null;
 
+    // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+    // 이벤트 조건 입력 검증 — 정책: eventPrice <= price_general, startAt < endAt
+    const ec = input.eventConditions;
+    if (ec) {
+      if (!Number.isFinite(ec.eventPrice) || ec.eventPrice <= 0) {
+        throw new EventOfferCreateError(400, 'eventPrice 는 0 보다 큰 숫자여야 합니다.', 'INTERNAL_ERROR');
+      }
+      const generalPrice = offer.price_general != null ? Number(offer.price_general) : null;
+      if (generalPrice != null && ec.eventPrice > generalPrice) {
+        throw new EventOfferCreateError(
+          400,
+          `이벤트 가격(${ec.eventPrice})은 일반 공급가(${generalPrice}) 이하여야 합니다.`,
+          'INTERNAL_ERROR',
+        );
+      }
+      const startMs = ec.startAt.getTime();
+      const endMs = ec.endAt.getTime();
+      if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+        throw new EventOfferCreateError(400, '시작/종료 일시 형식이 올바르지 않습니다.', 'INTERNAL_ERROR');
+      }
+      if (startMs >= endMs) {
+        throw new EventOfferCreateError(400, '시작 일시는 종료 일시보다 이전이어야 합니다.', 'INTERNAL_ERROR');
+      }
+      if (ec.totalQuantity != null && (!Number.isFinite(ec.totalQuantity) || ec.totalQuantity < 0)) {
+        throw new EventOfferCreateError(400, 'totalQuantity 는 0 이상이어야 합니다.', 'INTERNAL_ERROR');
+      }
+      if (ec.perOrderLimit != null && (!Number.isFinite(ec.perOrderLimit) || ec.perOrderLimit < 1)) {
+        throw new EventOfferCreateError(400, 'perOrderLimit 은 1 이상이어야 합니다.', 'INTERNAL_ERROR');
+      }
+      if (ec.perStoreLimit != null && (!Number.isFinite(ec.perStoreLimit) || ec.perStoreLimit < 1)) {
+        throw new EventOfferCreateError(400, 'perStoreLimit 은 1 이상이어야 합니다.', 'INTERNAL_ERROR');
+      }
+    }
+
     // 5. INSERT
     const listingRepo = this.dataSource.getRepository(OrganizationProductListing);
     const listing = listingRepo.create({
@@ -885,7 +986,15 @@ export class EventOfferService {
       service_key: input.serviceKey,
       is_active: isActive,
       status,
+      // 일반 공급가 스냅샷 (기존 로직 유지)
       price: offer.price_general != null ? Number(offer.price_general) : null,
+      // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 이벤트 전용 가격/기간/수량
+      event_price: ec ? ec.eventPrice : null,
+      start_at: ec ? ec.startAt : null,
+      end_at: ec ? ec.endAt : null,
+      total_quantity: ec?.totalQuantity ?? null,
+      per_order_limit: ec?.perOrderLimit ?? null,
+      per_store_limit: ec?.perStoreLimit ?? null,
       requested_by: requestedBy,
       decided_by: decidedBy,
       decided_at: decidedAt,
@@ -907,6 +1016,12 @@ export class EventOfferService {
       status,
       isActive,
       price: offer.price_general != null ? Number(offer.price_general) : null,
+      eventPrice: saved.event_price != null ? Number(saved.event_price) : null,
+      startAt: saved.start_at ? (saved.start_at instanceof Date ? saved.start_at.toISOString() : new Date(saved.start_at).toISOString()) : null,
+      endAt: saved.end_at ? (saved.end_at instanceof Date ? saved.end_at.toISOString() : new Date(saved.end_at).toISOString()) : null,
+      totalQuantity: saved.total_quantity != null ? Number(saved.total_quantity) : null,
+      perOrderLimit: saved.per_order_limit != null ? Number(saved.per_order_limit) : null,
+      perStoreLimit: saved.per_store_limit != null ? Number(saved.per_store_limit) : null,
       createdAt,
     };
   }
@@ -1040,6 +1155,14 @@ export class EventOfferService {
       productName: string;
       supplierName: string;
       price: number | null;
+      /** WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 운영자 승인 화면 가시성 */
+      eventPrice: number | null;
+      generalPrice: number | null;
+      startAt: string | null;
+      endAt: string | null;
+      totalQuantity: number | null;
+      perOrderLimit: number | null;
+      perStoreLimit: number | null;
       requestedBy: string | null;
       requestedByEmail: string | null;
       createdAt: string;
@@ -1064,9 +1187,16 @@ export class EventOfferService {
            opl.master_id       AS "masterId",
            opl.organization_id AS "organizationId",
            opl.price::numeric  AS "price",
+           opl.event_price::numeric AS "eventPrice",
+           opl.start_at        AS "startAt",
+           opl.end_at          AS "endAt",
+           opl.total_quantity  AS "totalQuantity",
+           opl.per_order_limit AS "perOrderLimit",
+           opl.per_store_limit AS "perStoreLimit",
            opl.requested_by    AS "requestedBy",
            opl.created_at      AS "createdAt",
            u.email             AS "requestedByEmail",
+           spo.price_general::numeric AS "generalPrice",
            COALESCE(pm.name, '(상품명 없음)')  AS "productName",
            COALESCE(org.name, '(공급사 없음)') AS "supplierName"
          FROM organization_product_listings opl
@@ -1091,6 +1221,13 @@ export class EventOfferService {
         productName: r.productName,
         supplierName: r.supplierName,
         price: r.price !== null ? Number(r.price) : null,
+        eventPrice: r.eventPrice !== null ? Number(r.eventPrice) : null,
+        generalPrice: r.generalPrice !== null ? Number(r.generalPrice) : null,
+        startAt: r.startAt ? new Date(r.startAt).toISOString() : null,
+        endAt: r.endAt ? new Date(r.endAt).toISOString() : null,
+        totalQuantity: r.totalQuantity !== null ? Number(r.totalQuantity) : null,
+        perOrderLimit: r.perOrderLimit !== null ? Number(r.perOrderLimit) : null,
+        perStoreLimit: r.perStoreLimit !== null ? Number(r.perStoreLimit) : null,
         requestedBy: r.requestedBy,
         requestedByEmail: r.requestedByEmail,
         createdAt: r.createdAt instanceof Date
@@ -1124,6 +1261,18 @@ export class EventOfferService {
     offerId: string;
     targetServiceKeys: string[];
     ownerUserId: string;
+    /**
+     * WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+     * supplier 가 지정한 이벤트 조건 — 모든 대상 서비스 row 에 동일하게 적용.
+     */
+    eventConditions?: {
+      eventPrice: number;
+      startAt: Date;
+      endAt: Date;
+      totalQuantity?: number | null;
+      perOrderLimit?: number | null;
+      perStoreLimit?: number | null;
+    };
   }): Promise<{
     offerId: string;
     results: Array<{
@@ -1197,6 +1346,8 @@ export class EventOfferService {
           organizationId,
           roleType: 'supplier',
           ownerUserId: input.ownerUserId,
+          // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+          eventConditions: input.eventConditions,
         });
         results.push({
           targetServiceKey: target,

--- a/apps/api-server/src/routes/neture/controllers/supplier-event-offer-proposals.controller.ts
+++ b/apps/api-server/src/routes/neture/controllers/supplier-event-offer-proposals.controller.ts
@@ -63,10 +63,18 @@ export function createSupplierEventOfferProposalsController(
         return;
       }
 
-      const { offerId, serviceKeys } = (req.body ?? {}) as {
+      const body = (req.body ?? {}) as {
         offerId?: string;
         serviceKeys?: unknown;
+        // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+        eventPrice?: unknown;
+        startAt?: unknown;
+        endAt?: unknown;
+        totalQuantity?: unknown;
+        perOrderLimit?: unknown;
+        perStoreLimit?: unknown;
       };
+      const { offerId, serviceKeys } = body;
 
       if (!offerId || typeof offerId !== 'string') {
         res.status(400).json({
@@ -94,6 +102,77 @@ export function createSupplierEventOfferProposalsController(
         return;
       }
 
+      // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+      // 이벤트 조건 검증 — 정책: eventPrice/startAt/endAt 필수, 기간 미입력 금지.
+      const eventPriceNum =
+        typeof body.eventPrice === 'number'
+          ? body.eventPrice
+          : typeof body.eventPrice === 'string' && body.eventPrice.trim() !== ''
+            ? Number(body.eventPrice)
+            : NaN;
+      if (!Number.isFinite(eventPriceNum) || eventPriceNum <= 0) {
+        res.status(400).json({
+          success: false,
+          error: { code: 'INVALID_PARAMS', message: 'eventPrice 는 0 보다 큰 숫자여야 합니다.' },
+        });
+        return;
+      }
+
+      const startAt =
+        typeof body.startAt === 'string' && body.startAt.trim() !== ''
+          ? new Date(body.startAt)
+          : null;
+      const endAt =
+        typeof body.endAt === 'string' && body.endAt.trim() !== ''
+          ? new Date(body.endAt)
+          : null;
+      if (!startAt || Number.isNaN(startAt.getTime())) {
+        res.status(400).json({
+          success: false,
+          error: { code: 'INVALID_PARAMS', message: '시작 일시(startAt)가 필요합니다.' },
+        });
+        return;
+      }
+      if (!endAt || Number.isNaN(endAt.getTime())) {
+        res.status(400).json({
+          success: false,
+          error: { code: 'INVALID_PARAMS', message: '종료 일시(endAt)가 필요합니다.' },
+        });
+        return;
+      }
+      if (startAt.getTime() >= endAt.getTime()) {
+        res.status(400).json({
+          success: false,
+          error: { code: 'INVALID_PARAMS', message: '시작 일시는 종료 일시보다 이전이어야 합니다.' },
+        });
+        return;
+      }
+
+      const parseOptionalInt = (v: unknown, name: string): number | null | { error: string } => {
+        if (v == null || v === '') return null;
+        const n = typeof v === 'number' ? v : Number(v);
+        if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+          return { error: `${name} 는 0 이상의 정수여야 합니다.` };
+        }
+        return n;
+      };
+
+      const totalQuantity = parseOptionalInt(body.totalQuantity, 'totalQuantity');
+      if (totalQuantity && typeof totalQuantity === 'object' && 'error' in totalQuantity) {
+        res.status(400).json({ success: false, error: { code: 'INVALID_PARAMS', message: totalQuantity.error } });
+        return;
+      }
+      const perOrderLimit = parseOptionalInt(body.perOrderLimit, 'perOrderLimit');
+      if (perOrderLimit && typeof perOrderLimit === 'object' && 'error' in perOrderLimit) {
+        res.status(400).json({ success: false, error: { code: 'INVALID_PARAMS', message: perOrderLimit.error } });
+        return;
+      }
+      const perStoreLimit = parseOptionalInt(body.perStoreLimit, 'perStoreLimit');
+      if (perStoreLimit && typeof perStoreLimit === 'object' && 'error' in perStoreLimit) {
+        res.status(400).json({ success: false, error: { code: 'INVALID_PARAMS', message: perStoreLimit.error } });
+        return;
+      }
+
       // 공급자 계정 연결 확인 (UI fast-fail)
       const supplierId = await resolveSupplierIdByUser(dataSource, userId);
       if (!supplierId) {
@@ -112,6 +191,14 @@ export function createSupplierEventOfferProposalsController(
         offerId,
         targetServiceKeys: cleanKeys,
         ownerUserId: userId,
+        eventConditions: {
+          eventPrice: eventPriceNum,
+          startAt,
+          endAt,
+          totalQuantity: totalQuantity as number | null,
+          perOrderLimit: perOrderLimit as number | null,
+          perStoreLimit: perStoreLimit as number | null,
+        },
       });
 
       res.status(201).json({
@@ -164,6 +251,12 @@ export function createSupplierEventOfferProposalsController(
            opl.created_at      AS "proposedAt",
            opl.decided_at      AS "decidedAt",
            opl.rejected_reason AS "rejectedReason",
+           opl.event_price::numeric AS "eventPrice",
+           opl.start_at        AS "startAt",
+           opl.end_at          AS "endAt",
+           opl.total_quantity  AS "totalQuantity",
+           opl.per_order_limit AS "perOrderLimit",
+           opl.per_store_limit AS "perStoreLimit",
            COALESCE(pm.name, '(상품명 없음)')  AS title,
            COALESCE(org.name, '(공급사 없음)') AS "supplierName",
            spo.price_general::numeric          AS price
@@ -185,6 +278,13 @@ export function createSupplierEventOfferProposalsController(
         title: r.title,
         supplierName: r.supplierName,
         price: r.price !== null ? Number(r.price) : null,
+        // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+        eventPrice: r.eventPrice !== null ? Number(r.eventPrice) : null,
+        startAt: r.startAt ? new Date(r.startAt).toISOString() : null,
+        endAt: r.endAt ? new Date(r.endAt).toISOString() : null,
+        totalQuantity: r.totalQuantity !== null ? Number(r.totalQuantity) : null,
+        perOrderLimit: r.perOrderLimit !== null ? Number(r.perOrderLimit) : null,
+        perStoreLimit: r.perStoreLimit !== null ? Number(r.perStoreLimit) : null,
         isActive: r.isActive,
         status: r.status,
         proposedAt: r.proposedAt instanceof Date

--- a/services/web-kpa-society/src/api/eventOffer.ts
+++ b/services/web-kpa-society/src/api/eventOffer.ts
@@ -35,10 +35,11 @@ export const eventOfferApi = {
 
   // 이벤트 상품 목록 (enriched, WO-EVENT-OFFER-HUB-TABLE-AND-DIRECT-ORDER-REFINE-V1)
   // WO-EVENT-OFFER-HUB-TIME-WINDOW-FILTER-HOTFIX-V1: status 필터 추가
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 'upcoming' 추가
   getEnrichedOffers: (params?: {
     page?: number;
     limit?: number;
-    status?: 'active' | 'ended' | 'all';
+    status?: 'upcoming' | 'active' | 'ended' | 'all';
   }) =>
     apiClient.get<{
       success: boolean;

--- a/services/web-kpa-society/src/components/event-offer/EventOfferContentPanel.tsx
+++ b/services/web-kpa-society/src/components/event-offer/EventOfferContentPanel.tsx
@@ -35,9 +35,11 @@ interface OrderResult {
   error?: string;
 }
 
+// WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 'upcoming' 추가
 type StatusTab = { key: EventOfferStatus; label: string };
 const STATUS_TABS: StatusTab[] = [
-  { key: 'active', label: '진행중' },
+  { key: 'upcoming', label: '진행 예정' },
+  { key: 'active', label: '진행 중' },
   { key: 'ended', label: '종료' },
   { key: 'all', label: '전체' },
 ];
@@ -119,13 +121,14 @@ export function EventOfferContentPanel({ compact = false }: EventOfferContentPan
     return result;
   }, [items, supplierFilter, searchQuery]);
 
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 진행 중(active) 만 주문 가능
   const selectableItems = useMemo(
-    () => filteredItems.filter(i => i.isActive),
+    () => filteredItems.filter(i => i.status === 'active'),
     [filteredItems],
   );
 
   const groupedSelection = useMemo(() => {
-    const selected = items.filter(i => selectedIds.has(i.id) && i.isActive);
+    const selected = items.filter(i => selectedIds.has(i.id) && i.status === 'active');
     const groups: Record<string, EventOfferItem[]> = {};
     for (const item of selected) {
       if (!groups[item.supplierName]) groups[item.supplierName] = [];
@@ -201,7 +204,7 @@ export function EventOfferContentPanel({ compact = false }: EventOfferContentPan
   };
 
   const handleOrderAll = async () => {
-    const allItems = items.filter(i => selectedIds.has(i.id) && i.isActive);
+    const allItems = items.filter(i => selectedIds.has(i.id) && i.status === 'active');
     await handleBatchOrder(allItems);
   };
 
@@ -216,15 +219,23 @@ export function EventOfferContentPanel({ compact = false }: EventOfferContentPan
   const formatPeriod = (item: EventOfferItem) => {
     const start = item.startAt ? formatDate(item.startAt) : formatDate(item.createdAt);
     const end = item.endAt ? formatDate(item.endAt) : null;
-    if (item.status === 'active' || (item.status === 'approved' && !item.startAt)) return `${start} ~`;
+    if (item.status === 'active' && !item.startAt) return `${start} ~`;
     if (end) return `${start} ~ ${end}`;
     return `${start} ~`;
   };
 
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
   const getStatusBadge = (item: EventOfferItem): { style: React.CSSProperties; label: string } => {
-    if (item.status === 'approved') return { style: badgeSoon, label: '곧 시작' };
-    if (item.status === 'active' || item.isActive) return { style: badgeActive, label: '진행중' };
-    return { style: badgeEnded, label: '종료' };
+    switch (item.status) {
+      case 'upcoming':  return { style: badgeSoon, label: '곧 시작' };
+      case 'active':    return { style: badgeActive, label: '진행중' };
+      case 'sold_out':  return { style: badgeEnded, label: '매진' };
+      case 'pending':   return { style: badgeEnded, label: '대기' };
+      case 'rejected':  return { style: badgeEnded, label: '반려' };
+      case 'canceled':  return { style: badgeEnded, label: '취소' };
+      case 'ended':
+      default:          return { style: badgeEnded, label: '종료' };
+    }
   };
 
   const getGroupSubtotal = (groupItems: EventOfferItem[]) =>
@@ -323,17 +334,21 @@ export function EventOfferContentPanel({ compact = false }: EventOfferContentPan
               <span style={{ ...colCenter, width: 100 }}>액션</span>
             </div>
 
-            {filteredItems.map(item => (
+            {/* WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+                upcoming(시작 전) 노출 + 주문 비활성, active 만 주문 가능, sold_out/ended 분리 표시 */}
+            {filteredItems.map(item => {
+              const isOrderable = item.status === 'active';
+              return (
               <div
                 key={item.id}
                 style={{
                   ...listRow,
-                  ...(!item.isActive ? { opacity: 0.6, backgroundColor: colors.neutral50 } : {}),
+                  ...(!isOrderable ? { opacity: 0.7, backgroundColor: colors.neutral50 } : {}),
                 }}
               >
                 {hasStore && statusFilter !== 'ended' && (
                   <span style={{ ...colCenter, width: 48 }}>
-                    {item.isActive ? (
+                    {isOrderable ? (
                       <input
                         type="checkbox"
                         checked={selectedIds.has(item.id)}
@@ -368,19 +383,24 @@ export function EventOfferContentPanel({ compact = false }: EventOfferContentPan
                 <span style={{ ...colCenter, width: 80 }}>
                   {(() => { const b = getStatusBadge(item); return <span style={b.style}>{b.label}</span>; })()}
                 </span>
-                <span style={{ ...colCenter, width: 100 }}>
-                  {item.isActive && hasStore ? (
+                <span style={{ ...colCenter, width: 110 }}>
+                  {item.status === 'upcoming' ? (
+                    <span style={disabledText}>곧 시작</span>
+                  ) : item.status === 'sold_out' ? (
+                    <span style={disabledText}>매진</span>
+                  ) : isOrderable && hasStore ? (
                     <button style={orderBtn} onClick={() => handleDirectOrder(item)}>
                       내 매장에 추가
                     </button>
-                  ) : item.isActive && !hasStore ? (
+                  ) : isOrderable && !hasStore ? (
                     <span style={disabledText}>매장 필요</span>
                   ) : (
                     <span style={disabledText}>종료됨</span>
                   )}
                 </span>
               </div>
-            ))}
+              );
+            })}
 
             {filteredItems.length === 0 && (
               <div style={emptyRow}>검색 결과가 없습니다.</div>

--- a/services/web-kpa-society/src/pages/event-offer/KpaEventOfferPage.tsx
+++ b/services/web-kpa-society/src/pages/event-offer/KpaEventOfferPage.tsx
@@ -29,9 +29,11 @@ interface OrderResult {
   error?: string;
 }
 
+// WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 4-탭 (진행 예정/진행 중/종료/전체)
 type StatusTab = { key: EventOfferStatus; label: string };
 const STATUS_TABS: StatusTab[] = [
-  { key: 'active', label: '진행중' },
+  { key: 'upcoming', label: '진행 예정' },
+  { key: 'active', label: '진행 중' },
   { key: 'ended', label: '종료' },
   { key: 'all', label: '전체' },
 ];
@@ -126,14 +128,15 @@ export function KpaEventOfferPage() {
     return result;
   }, [items, supplierFilter, searchQuery]);
 
-  // 진행중 항목만 선택 가능
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+  // 진행 중(active) 항목만 주문 선택 가능. upcoming/sold_out/ended/canceled 제외.
   const selectableItems = useMemo(
-    () => filteredItems.filter(i => i.isActive),
+    () => filteredItems.filter(i => i.status === 'active'),
     [filteredItems],
   );
 
   const groupedSelection = useMemo(() => {
-    const selected = items.filter(i => selectedIds.has(i.id) && i.isActive);
+    const selected = items.filter(i => selectedIds.has(i.id) && i.status === 'active');
     const groups: Record<string, EventOfferItem[]> = {};
     for (const item of selected) {
       if (!groups[item.supplierName]) groups[item.supplierName] = [];
@@ -230,16 +233,34 @@ export function KpaEventOfferPage() {
   const formatPeriod = (item: EventOfferItem) => {
     const start = item.startAt ? formatDate(item.startAt) : formatDate(item.createdAt);
     const end = item.endAt ? formatDate(item.endAt) : null;
-    if (item.status === 'active' || (item.status === 'approved' && !item.startAt)) return `${start} ~`;
+    if (item.status === 'active' && !item.startAt) return `${start} ~`;
     if (end) return `${start} ~ ${end}`;
     return `${start} ~`;
   };
 
-  // WO-O4O-EVENT-OFFER-CORE-REFORM-V1: 런타임 상태 기반 배지
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 4-상태 + sold_out/rejected/canceled 배지
   const getStatusBadge = (item: EventOfferItem): { style: React.CSSProperties; label: string } => {
-    if (item.status === 'approved') return { style: styles.badgeSoon, label: '곧 시작' };
-    if (item.status === 'active' || item.isActive) return { style: styles.badgeActive, label: '진행중' };
-    return { style: styles.badgeEnded, label: '종료' };
+    switch (item.status) {
+      case 'upcoming':  return { style: styles.badgeSoon, label: '곧 시작' };
+      case 'active':    return { style: styles.badgeActive, label: '진행중' };
+      case 'sold_out':  return { style: styles.badgeEnded, label: '매진' };
+      case 'pending':   return { style: styles.badgeEnded, label: '대기' };
+      case 'rejected':  return { style: styles.badgeEnded, label: '반려' };
+      case 'canceled':  return { style: styles.badgeEnded, label: '취소' };
+      case 'ended':
+      default:          return { style: styles.badgeEnded, label: '종료' };
+    }
+  };
+
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 할인 정보
+  const getDiscount = (item: EventOfferItem): { amount: number; rate: number } | null => {
+    if (item.eventPrice == null || item.generalPrice == null) return null;
+    const ep = Number(item.eventPrice);
+    const gp = Number(item.generalPrice);
+    if (!Number.isFinite(ep) || !Number.isFinite(gp) || gp <= 0 || ep >= gp) return null;
+    const amount = gp - ep;
+    const rate = Math.round((amount / gp) * 100);
+    return { amount, rate };
   };
 
   const getGroupSubtotal = (groupItems: EventOfferItem[]) =>
@@ -388,18 +409,28 @@ export function KpaEventOfferPage() {
               <span style={{ ...styles.colCenter, width: 100 }}>액션</span>
             </div>
 
-            {/* Rows */}
-            {filteredItems.map(item => (
+            {/* Rows
+                WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+                - 가격 컬럼: 이벤트 가격 + 기존 가격 strikethrough + 할인율
+                - 주문 버튼:
+                    upcoming  → "내일부터 시작" disabled
+                    active    → "주문" enabled (매장 있을 때)
+                    ended/sold_out/canceled → 종료/매진/취소 표시 disabled
+            */}
+            {filteredItems.map(item => {
+              const isOrderable = item.status === 'active';
+              const discount = getDiscount(item);
+              return (
               <div
                 key={item.id}
                 style={{
                   ...styles.listRow,
-                  ...(!item.isActive ? { opacity: 0.6, backgroundColor: colors.neutral50 } : {}),
+                  ...(!isOrderable ? { opacity: 0.7, backgroundColor: colors.neutral50 } : {}),
                 }}
               >
                 {hasStore && statusFilter !== 'ended' && (
                   <span style={{ ...styles.colCenter, width: 48 }}>
-                    {item.isActive ? (
+                    {isOrderable ? (
                       <input
                         type="checkbox"
                         checked={selectedIds.has(item.id)}
@@ -419,31 +450,53 @@ export function KpaEventOfferPage() {
                 <span style={{ ...styles.col, flex: 2, color: colors.neutral600, fontSize: 13 }}>
                   {item.supplierName}
                 </span>
-                <span style={{ ...styles.colRight, width: 120, fontWeight: 600 }}>
-                  {formatPrice(item.unitPrice)}
-                </span>
+                <div style={{ ...styles.colRight, width: 140 }}>
+                  <div style={{ fontWeight: 700, fontSize: 14, color: discount ? '#DC2626' : colors.neutral900 }}>
+                    {formatPrice(item.unitPrice)}
+                  </div>
+                  {discount && item.generalPrice != null && (
+                    <>
+                      <div style={{ fontSize: 11, color: colors.neutral400, textDecoration: 'line-through' }}>
+                        {formatPrice(item.generalPrice)}
+                      </div>
+                      <div style={{ fontSize: 11, fontWeight: 600, color: '#DC2626' }}>
+                        -{discount.rate}%
+                      </div>
+                    </>
+                  )}
+                  {item.totalQuantity != null && (
+                    <div style={{ fontSize: 11, color: item.totalQuantity <= 10 ? '#D97706' : colors.neutral500, marginTop: 2 }}>
+                      잔여 {item.totalQuantity.toLocaleString()}개
+                    </div>
+                  )}
+                </div>
                 <span style={{ ...styles.colCenter, width: 140, fontSize: 12, color: colors.neutral500 }}>
                   {formatPeriod(item)}
                 </span>
                 <span style={{ ...styles.colCenter, width: 80 }}>
                   {(() => { const b = getStatusBadge(item); return <span style={b.style}>{b.label}</span>; })()}
                 </span>
-                <span style={{ ...styles.colCenter, width: 100 }}>
-                  {item.isActive && hasStore ? (
+                <span style={{ ...styles.colCenter, width: 110 }}>
+                  {item.status === 'upcoming' ? (
+                    <span style={styles.disabledText}>곧 시작</span>
+                  ) : item.status === 'sold_out' ? (
+                    <span style={styles.disabledText}>매진</span>
+                  ) : isOrderable && hasStore ? (
                     <button
                       style={styles.orderBtn}
                       onClick={() => handleDirectOrder(item)}
                     >
                       주문
                     </button>
-                  ) : item.isActive && !hasStore ? (
+                  ) : isOrderable && !hasStore ? (
                     <span style={styles.disabledText}>매장 필요</span>
                   ) : (
                     <span style={styles.disabledText}>종료됨</span>
                   )}
                 </span>
               </div>
-            ))}
+              );
+            })}
 
             {filteredItems.length === 0 && (
               <div style={styles.emptyRow}>

--- a/services/web-kpa-society/src/types/index.ts
+++ b/services/web-kpa-society/src/types/index.ts
@@ -315,13 +315,27 @@ export interface EventOfferProduct {
 // 이벤트 상품 (Enriched, WO-EVENT-OFFER-HUB-TABLE-AND-DIRECT-ORDER-REFINE-V1)
 // WO-O4O-EVENT-OFFER-CORE-REFORM-V1: status / startAt / endAt 추가
 // WO-O4O-EVENT-OFFER-QUANTITY-LIMITS-V2: 수량 필드 추가
+// WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: eventPrice / generalPrice / 신규 status
 export interface EventOfferItem {
   id: string;
   offerId: string;
   price: number | null;
+  /** 이벤트 전용 공급가 (null = 레거시 listing) */
+  eventPrice: number | null;
+  /** 일반 공급가 (price_general 스냅샷). 비교 표시용. */
+  generalPrice: number | null;
   isActive: boolean;
-  /** 런타임 계산 상태: pending | approved(곧 시작) | active(진행중) | ended(종료) | canceled */
-  status: 'pending' | 'approved' | 'active' | 'ended' | 'canceled';
+  /**
+   * 런타임 계산 상태:
+   * - pending: 운영자 승인 대기
+   * - rejected: 반려
+   * - canceled: 취소
+   * - upcoming: 승인됨, 시작 전
+   * - active: 진행 중
+   * - sold_out: 매진
+   * - ended: 종료
+   */
+  status: 'pending' | 'rejected' | 'canceled' | 'upcoming' | 'active' | 'sold_out' | 'ended';
   startAt: string | null;
   endAt: string | null;
   createdAt: string;
@@ -336,8 +350,10 @@ export interface EventOfferItem {
   perStoreLimit: number | null;
 }
 
-// 이벤트 상태 (WO-EVENT-OFFER-HUB-TIME-WINDOW-FILTER-HOTFIX-V1)
-export type EventOfferStatus = 'active' | 'ended' | 'all';
+// 이벤트 상태 — KPA 매장 경영자 탭 키
+// WO-EVENT-OFFER-HUB-TIME-WINDOW-FILTER-HOTFIX-V1
+// WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 'upcoming' 추가
+export type EventOfferStatus = 'upcoming' | 'active' | 'ended' | 'all';
 
 // 이벤트 오퍼 (캠페인 모델 - legacy)
 export interface LegacyEventOffer {

--- a/services/web-neture/src/lib/api/index.ts
+++ b/services/web-neture/src/lib/api/index.ts
@@ -92,6 +92,8 @@ export {
   type ProposalStatus,
   type PerServiceProposalResult,
   type MultiServiceProposalResult,
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+  type ProposeEventConditions,
 } from './supplier.js';
 
 // Seller API

--- a/services/web-neture/src/lib/api/supplier.ts
+++ b/services/web-neture/src/lib/api/supplier.ts
@@ -983,6 +983,7 @@ export interface ProposeOfferResult {
 
 // WO-O4O-EVENT-OFFER-APPROVAL-PHASE1-V1
 // WO-O4O-EVENT-OFFER-MULTI-SERVICE-PROPOSAL-V1: serviceKey 필드 추가 (KPA + K-Cos 통합)
+// WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 이벤트 조건 필드 추가
 export interface MyEventOfferProposal {
   id: string;
   offerId: string;
@@ -990,12 +991,31 @@ export interface MyEventOfferProposal {
   serviceKey: string;
   title: string;
   supplierName: string;
+  /** 일반 공급가 (price_general) */
   price: number | null;
+  /** WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 이벤트 전용 가격/기간/수량 */
+  eventPrice: number | null;
+  startAt: string | null;
+  endAt: string | null;
+  totalQuantity: number | null;
+  perOrderLimit: number | null;
+  perStoreLimit: number | null;
   isActive: boolean;
   status: 'pending' | 'approved' | 'rejected' | 'canceled';
   proposedAt: string;
   decidedAt: string | null;
   rejectedReason: string | null;
+}
+
+// WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: supplier 가 제안 시 입력하는 이벤트 조건
+export interface ProposeEventConditions {
+  eventPrice: number;
+  /** ISO date string (YYYY-MM-DD or full ISO) */
+  startAt: string;
+  endAt: string;
+  totalQuantity?: number | null;
+  perOrderLimit?: number | null;
+  perStoreLimit?: number | null;
 }
 
 // WO-O4O-EVENT-OFFER-MULTI-SERVICE-PROPOSAL-V1
@@ -1078,18 +1098,33 @@ export const supplierKpaEventOfferApi = {
       ),
 
   // WO-O4O-EVENT-OFFER-MULTI-SERVICE-PROPOSAL-V1
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: eventConditions 파라미터 추가
   /**
    * 단일 SPO를 여러 대상 서비스(KPA / K-Cos)로 동시 제안.
    * 부분 실패 허용 — results 배열에서 서비스별 status 확인.
+   *
+   * eventConditions: 이벤트 가격/기간/수량 — 각 서비스 row 에 동일 적용.
+   *   - 일반 공급가/소비자가는 절대 변경되지 않는다 (정책).
+   *   - eventPrice <= 일반 공급가, startAt < endAt — 백엔드 추가 검증.
    */
   proposeEventOfferToServices: (
     offerId: string,
     serviceKeys: string[],
+    eventConditions: ProposeEventConditions,
   ): Promise<MultiServiceProposalResult> =>
     api
       .post<{ success: boolean; data: MultiServiceProposalResult }>(
         '/neture/supplier/event-offer-proposals',
-        { offerId, serviceKeys },
+        {
+          offerId,
+          serviceKeys,
+          eventPrice: eventConditions.eventPrice,
+          startAt: eventConditions.startAt,
+          endAt: eventConditions.endAt,
+          totalQuantity: eventConditions.totalQuantity ?? null,
+          perOrderLimit: eventConditions.perOrderLimit ?? null,
+          perStoreLimit: eventConditions.perStoreLimit ?? null,
+        },
       )
       .then(
         (res: { data: { success: boolean; data: MultiServiceProposalResult } }) =>

--- a/services/web-neture/src/pages/supplier/SupplierEventOfferPage.tsx
+++ b/services/web-neture/src/pages/supplier/SupplierEventOfferPage.tsx
@@ -15,12 +15,17 @@
  * - 신규: 자기 SPO 중에서 KPA 이벤트로 제안 (POST /kpa/supplier/event-offers)
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Tag, ChevronLeft, ChevronRight, Package, Plus, X, Loader2 } from 'lucide-react';
 import { toast } from '@o4o/error-handling';
 import { netureEventOfferApi, supplierKpaEventOfferApi } from '../../lib/api';
-import type { ProposableOffer, MyEventOfferProposal, PerServiceProposalResult } from '../../lib/api';
+import type {
+  ProposableOffer,
+  MyEventOfferProposal,
+  PerServiceProposalResult,
+  ProposeEventConditions,
+} from '../../lib/api';
 import { GuideBlock } from '@o4o/shared-space-ui';
 import { fetchGuidePageContent } from '../../api/guideContent';
 
@@ -168,6 +173,67 @@ export default function SupplierEventOfferPage() {
     );
   }, []);
 
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 이벤트 조건 입력 상태
+  // - eventPrice: 필수, 0보다 커야 함, 일반 공급가 이하
+  // - startAt / endAt: 필수, startAt < endAt
+  // - totalQuantity / perOrderLimit / perStoreLimit: optional
+  const [selectedOfferId, setSelectedOfferId] = useState<string | null>(null);
+  const [eventPrice, setEventPrice] = useState<string>('');
+  const [startAt, setStartAt] = useState<string>(''); // datetime-local
+  const [endAt, setEndAt] = useState<string>('');
+  const [totalQuantity, setTotalQuantity] = useState<string>('');
+  const [perOrderLimit, setPerOrderLimit] = useState<string>('');
+  const [perStoreLimit, setPerStoreLimit] = useState<string>('');
+
+  const selectedOffer = useMemo(
+    () => proposableOffers.find(o => o.id === selectedOfferId) ?? null,
+    [proposableOffers, selectedOfferId],
+  );
+
+  const resetEventConditionInputs = useCallback(() => {
+    setSelectedOfferId(null);
+    setEventPrice('');
+    setStartAt('');
+    setEndAt('');
+    setTotalQuantity('');
+    setPerOrderLimit('');
+    setPerStoreLimit('');
+  }, []);
+
+  /** 입력값 검증 결과를 반환. error 없으면 null. */
+  const validateEventConditions = useCallback((): string | null => {
+    if (!selectedOffer) return '제안할 상품을 먼저 선택하세요.';
+    const epNum = Number(eventPrice);
+    if (!eventPrice || !Number.isFinite(epNum) || epNum <= 0) {
+      return '이벤트 가격을 0보다 큰 숫자로 입력하세요.';
+    }
+    if (selectedOffer.price != null && epNum > Number(selectedOffer.price)) {
+      return `이벤트 가격은 일반 공급가(₩${Number(selectedOffer.price).toLocaleString()}) 이하여야 합니다.`;
+    }
+    if (!startAt) return '시작 일시를 입력하세요.';
+    if (!endAt) return '종료 일시를 입력하세요.';
+    const startMs = new Date(startAt).getTime();
+    const endMs = new Date(endAt).getTime();
+    if (!Number.isFinite(startMs)) return '시작 일시 형식이 올바르지 않습니다.';
+    if (!Number.isFinite(endMs)) return '종료 일시 형식이 올바르지 않습니다.';
+    if (startMs >= endMs) return '시작 일시는 종료 일시보다 이전이어야 합니다.';
+    const checkOptionalInt = (v: string, label: string): string | null => {
+      if (!v) return null;
+      const n = Number(v);
+      if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+        return `${label}는 0 이상의 정수여야 합니다.`;
+      }
+      return null;
+    };
+    return (
+      checkOptionalInt(totalQuantity, '총 수량') ||
+      checkOptionalInt(perOrderLimit, '1회 주문 제한') ||
+      checkOptionalInt(perStoreLimit, '매장별 제한')
+    );
+  }, [selectedOffer, eventPrice, startAt, endAt, totalQuantity, perOrderLimit, perStoreLimit]);
+
+  const validationError = validateEventConditions();
+
   // WO-O4O-EVENT-OFFER-APPROVAL-PHASE1-V1: 내 제안 현황
   const [myProposals, setMyProposals] = useState<MyEventOfferProposal[]>([]);
   const [proposalsLoading, setProposalsLoading] = useState(false);
@@ -222,28 +288,51 @@ export default function SupplierEventOfferPage() {
     setProposeOpen(true);
     // 모달 열 때마다 기본값(KPA Society)으로 초기화
     setSelectedTargets(['kpa-society']);
+    resetEventConditionInputs();
     loadProposableOffers();
-  }, [loadProposableOffers]);
+  }, [loadProposableOffers, resetEventConditionInputs]);
 
   const handleClosePropose = useCallback(() => {
     setProposeOpen(false);
     setProposableOffers([]);
     setProposingId(null);
-  }, []);
+    resetEventConditionInputs();
+  }, [resetEventConditionInputs]);
 
   // WO-O4O-EVENT-OFFER-MULTI-SERVICE-PROPOSAL-V1
+  // WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1: 이벤트 조건 입력 → API 전달
   // 단일 SPO를 선택된 대상 서비스(KPA / K-Cos)로 동시 제안.
   // 부분 실패 허용 — 서비스별 결과를 각각 toast로 표시.
-  const handlePropose = useCallback(async (offerId: string, title: string) => {
+  const handlePropose = useCallback(async () => {
+    if (!selectedOffer) {
+      toast.error('제안할 상품을 선택하세요.');
+      return;
+    }
     if (selectedTargets.length === 0) {
       toast.error('대상 서비스를 1개 이상 선택해 주세요.');
       return;
     }
-    setProposingId(offerId);
+    const errMsg = validateEventConditions();
+    if (errMsg) {
+      toast.error(errMsg);
+      return;
+    }
+
+    const conditions: ProposeEventConditions = {
+      eventPrice: Number(eventPrice),
+      startAt: new Date(startAt).toISOString(),
+      endAt: new Date(endAt).toISOString(),
+      totalQuantity: totalQuantity ? Number(totalQuantity) : null,
+      perOrderLimit: perOrderLimit ? Number(perOrderLimit) : null,
+      perStoreLimit: perStoreLimit ? Number(perStoreLimit) : null,
+    };
+
+    setProposingId(selectedOffer.id);
     try {
       const result = await supplierKpaEventOfferApi.proposeEventOfferToServices(
-        offerId,
+        selectedOffer.id,
         selectedTargets,
+        conditions,
       );
 
       // 서비스별 결과 표시
@@ -270,7 +359,7 @@ export default function SupplierEventOfferPage() {
       }
       // 추가 안내: 모든 서비스에 성공한 경우
       if (createdCount === result.results.length && createdCount > 1) {
-        toast.success(`"${title}" 이(가) ${createdCount}개 서비스에 제안되었습니다.`);
+        toast.success(`"${selectedOffer.title}" 이(가) ${createdCount}개 서비스에 제안되었습니다.`);
       }
     } catch (err: unknown) {
       const code = extractErrorCode(err);
@@ -284,6 +373,8 @@ export default function SupplierEventOfferPage() {
   }, [
     page, activeTab, selectedTargets,
     fetchItems, handleClosePropose, loadProposableOffers, loadMyProposals,
+    selectedOffer, eventPrice, startAt, endAt,
+    totalQuantity, perOrderLimit, perStoreLimit, validateEventConditions,
   ]);
 
   useEffect(() => {
@@ -582,7 +673,9 @@ export default function SupplierEventOfferPage() {
             </div>
 
             {/* Modal Body */}
-            <div className="flex-1 overflow-y-auto px-6 py-4">
+            {/* WO-O4O-EVENT-OFFER-DATA-LIFECYCLE-COMPLETION-V1
+                Step 1: 상품 선택 (radio) — Step 2: 이벤트 조건 입력 — 하단 "제안하기" 버튼 */}
+            <div className="flex-1 overflow-y-auto px-6 py-4 space-y-5">
               {proposableLoading ? (
                 <div className="flex justify-center py-12">
                   <Loader2 size={24} className="animate-spin text-indigo-600" />
@@ -596,53 +689,190 @@ export default function SupplierEventOfferPage() {
                   </p>
                 </div>
               ) : (
-                <ul className="divide-y divide-slate-100">
-                  {proposableOffers.map((offer) => (
-                    <li
-                      key={offer.id}
-                      className="flex items-center justify-between gap-4 py-3"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm font-medium text-slate-800 truncate">
-                          {offer.title}
-                        </p>
-                        <p className="text-xs text-slate-500 truncate mt-0.5">
-                          {offer.supplierName}
-                          {offer.price != null && (
-                            <span className="ml-2 text-slate-700">
-                              · ₩{Number(offer.price).toLocaleString()}
-                            </span>
-                          )}
-                        </p>
-                      </div>
-                      <button
-                        onClick={() => handlePropose(offer.id, offer.title)}
-                        disabled={proposingId !== null || selectedTargets.length === 0}
-                        className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-md transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0"
-                      >
-                        {proposingId === offer.id ? (
-                          <>
-                            <Loader2 size={12} className="animate-spin" />
-                            제안 중...
-                          </>
-                        ) : (
-                          '제안'
+                <>
+                  {/* Step 1: 상품 선택 */}
+                  <div>
+                    <div className="text-xs font-semibold text-slate-700 mb-2">
+                      1. 제안할 상품 선택
+                    </div>
+                    <ul className="divide-y divide-slate-100 border border-slate-200 rounded-lg overflow-hidden">
+                      {proposableOffers.map((offer) => {
+                        const checked = selectedOfferId === offer.id;
+                        return (
+                          <li key={offer.id}>
+                            <label
+                              className={`flex items-center gap-3 px-3 py-2.5 cursor-pointer text-sm ${
+                                checked ? 'bg-indigo-50' : 'hover:bg-slate-50'
+                              }`}
+                            >
+                              <input
+                                type="radio"
+                                name="proposable-offer"
+                                checked={checked}
+                                onChange={() => setSelectedOfferId(offer.id)}
+                                disabled={proposingId !== null}
+                                className="w-3.5 h-3.5 accent-indigo-600"
+                              />
+                              <div className="min-w-0 flex-1">
+                                <p className="font-medium text-slate-800 truncate">
+                                  {offer.title}
+                                </p>
+                                <p className="text-xs text-slate-500 truncate mt-0.5">
+                                  {offer.supplierName}
+                                  {offer.price != null && (
+                                    <span className="ml-2 text-slate-700">
+                                      · 일반 공급가 ₩{Number(offer.price).toLocaleString()}
+                                    </span>
+                                  )}
+                                </p>
+                              </div>
+                            </label>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+
+                  {/* Step 2: 이벤트 조건 입력 */}
+                  <div className="space-y-3">
+                    <div className="text-xs font-semibold text-slate-700">
+                      2. 이벤트 조건 입력
+                    </div>
+
+                    {/* 이벤트 가격 */}
+                    <div>
+                      <label className="block text-xs text-slate-600 mb-1">
+                        이벤트 공급가 <span className="text-red-500">*</span>
+                        {selectedOffer?.price != null && (
+                          <span className="ml-1 text-slate-400">
+                            (일반 공급가 ₩{Number(selectedOffer.price).toLocaleString()} 이하)
+                          </span>
                         )}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
+                      </label>
+                      <input
+                        type="number"
+                        min={0}
+                        step={1}
+                        value={eventPrice}
+                        onChange={e => setEventPrice(e.target.value)}
+                        disabled={proposingId !== null}
+                        placeholder="예: 18000"
+                        className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                      />
+                    </div>
+
+                    {/* 시작/종료 일시 */}
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="block text-xs text-slate-600 mb-1">
+                          시작 일시 <span className="text-red-500">*</span>
+                        </label>
+                        <input
+                          type="datetime-local"
+                          value={startAt}
+                          onChange={e => setStartAt(e.target.value)}
+                          disabled={proposingId !== null}
+                          className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-slate-600 mb-1">
+                          종료 일시 <span className="text-red-500">*</span>
+                        </label>
+                        <input
+                          type="datetime-local"
+                          value={endAt}
+                          onChange={e => setEndAt(e.target.value)}
+                          disabled={proposingId !== null}
+                          className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        />
+                      </div>
+                    </div>
+
+                    {/* 수량 제한 (optional) */}
+                    <div className="grid grid-cols-3 gap-3">
+                      <div>
+                        <label className="block text-xs text-slate-600 mb-1">
+                          총 수량 <span className="text-slate-400">(선택)</span>
+                        </label>
+                        <input
+                          type="number"
+                          min={0}
+                          step={1}
+                          value={totalQuantity}
+                          onChange={e => setTotalQuantity(e.target.value)}
+                          disabled={proposingId !== null}
+                          placeholder="무제한"
+                          className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-slate-600 mb-1">
+                          1회 주문 제한 <span className="text-slate-400">(선택)</span>
+                        </label>
+                        <input
+                          type="number"
+                          min={1}
+                          step={1}
+                          value={perOrderLimit}
+                          onChange={e => setPerOrderLimit(e.target.value)}
+                          disabled={proposingId !== null}
+                          placeholder="무제한"
+                          className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-slate-600 mb-1">
+                          매장별 제한 <span className="text-slate-400">(선택)</span>
+                        </label>
+                        <input
+                          type="number"
+                          min={1}
+                          step={1}
+                          value={perStoreLimit}
+                          onChange={e => setPerStoreLimit(e.target.value)}
+                          disabled={proposingId !== null}
+                          placeholder="무제한"
+                          className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        />
+                      </div>
+                    </div>
+
+                    {validationError && (
+                      <p className="text-xs text-red-600">{validationError}</p>
+                    )}
+                  </div>
+                </>
               )}
             </div>
 
             {/* Modal Footer */}
-            <div className="flex items-center justify-end px-6 py-3 border-t border-slate-200">
+            <div className="flex items-center justify-end gap-2 px-6 py-3 border-t border-slate-200">
               <button
                 onClick={handleClosePropose}
                 disabled={proposingId !== null}
                 className="px-4 py-2 text-sm text-slate-600 hover:bg-slate-100 rounded-lg disabled:opacity-40"
               >
                 닫기
+              </button>
+              <button
+                onClick={handlePropose}
+                disabled={
+                  proposingId !== null ||
+                  proposableOffers.length === 0 ||
+                  selectedTargets.length === 0 ||
+                  validationError !== null
+                }
+                className="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {proposingId !== null ? (
+                  <>
+                    <Loader2 size={14} className="animate-spin" />
+                    제안 중...
+                  </>
+                ) : (
+                  '제안하기'
+                )}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- KPA canonical Event Offer 라이프사이클 완성: 공급자 등록 → 서비스 승인 → 시작 전 노출 → 진행 → 이벤트 가격 주문 → 종료 자동 제거
- `organization_product_listings.event_price` 컬럼 추가 (NUMERIC, 일반 공급가와 분리)
- 공급자 제안 시 이벤트 조건(가격/기간/수량/주문제한/매장제한) 입력·저장 라이프사이클 완성
- 매장 경영자(KPA) 화면: 4-탭 (진행 예정/진행 중/종료/전체) + 이벤트가/일반가/할인율 카드 + 상태별 주문 정책

## 변경 영역
- Backend
  - 마이그레이션: `20260915000000-AddEventPriceToOrgProductListings`
  - 엔티티 + `EventOfferService` (createListing/createMultiServiceProposal/participate/listGroupbuysEnriched/listPendingListings)
  - `resolveEventStatus`: pending/rejected/canceled/upcoming/active/sold_out/ended 7-상태
  - supplier proposals controller: 이벤트 조건 검증 (eventPrice 필수, startAt < endAt)
  - KPA `/enriched`: `?status=upcoming` 허용 (K-Cos/Neture 컨트롤러는 WO scope 외)
- Frontend
  - `web-neture` SupplierEventOfferPage: Step1 상품 선택 + Step2 조건 입력 + 검증
  - `web-kpa-society` KpaEventOfferPage / EventOfferContentPanel: 탭 + 카드 + 주문 버튼 정책

## 가격 무오염 보장
- `supplier_product_offers.price_general`, `products.*` 어떤 INSERT/UPDATE에서도 변경되지 않음
- 이벤트 가격은 `organization_product_listings.event_price`에만 저장
- 주문 시 `unitPrice = event_price ?? price_general` — `checkout_orders.items` JSONB 스냅샷에만 반영

## 호환성
- 기존 listing(event_price=NULL): `unitPrice` fallback이 `price_general` → 동작 보존
- K-Cos store는 별도 클라이언트(`?status=active`)로 호출 → 무수정, 자동으로 정확해진 active 필터 활용

## Test plan
- [ ] 시나리오 A: 공급자 등록 → upcoming 노출, KPA 매장 화면 "곧 시작" 표시, 주문 disabled
- [ ] 시나리오 B: start_at 도달 후 active 전환, 주문 가능, `unitPrice == event_price` 확인 (`checkout_orders.items[].unitPrice`)
- [ ] 시나리오 C: end_at 경과 후 active 목록 제거, 종료 탭에서 조회 가능
- [ ] 시나리오 D: 동일 SPO의 `price_general`이 변하지 않는지 DB 확인 (대상 상품: 롯데 자일리톨-그린 12갑 / barcode 2002875477749)
- [ ] 회귀: K-Cos `/cosmetics/event-offers/enriched?status=active` 정상 응답
- [ ] 회귀: 기존 KPA store 페이지 — 레거시 listing 노출 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)