### PR TITLE
fix(kpa): organization 주소·약국 전화 write 계약 정렬 (승인 + activity_type 전환 2경로)

### DIFF
--- a/apps/api-server/src/routes/kpa/controllers/__tests__/member.controller.infoOrgContactSync.test.ts
+++ b/apps/api-server/src/routes/kpa/controllers/__tests__/member.controller.infoOrgContactSync.test.ts
@@ -1,0 +1,380 @@
+/**
+ * WO-O4O-KPA-ACTIVITY-TYPE-PHARMACY-OWNER-ORGANIZATION-CONTACT-ALIGNMENT-V1
+ *
+ * PATCH /kpa/members/:id/info 에서 activity_type 을 `pharmacy_owner` 로 바꿔
+ * organization 을 생성·연결하는 경로의 **주소 · 약국 전화 초기화 계약**을 고정한다.
+ *
+ * 승인 경로(PATCH /:id/status)와 동일한 계약을 공유한다
+ *   (선행 commit 192086556 · `planKpaOrganizationContactSync` 재사용).
+ *
+ * 고정 항목:
+ *   - 신규 organization 은 resolver 결과로 초기화된다 (canonical → legacy → 구조화 fallback).
+ *   - 기존 organization 의 유효한 값은 덮어쓰지 않고, 비어 있는 항목만 키 단위로 보완한다.
+ *   - 대표 전화(businessInfo.phone)는 약국 전화로 승격되지 않는다.
+ *   - pharmacy_owner 전이가 아닌 요청은 organizations 를 건드리지 않는다.
+ *   - 연락처 동기화 실패는 권한 부여 · 응답 · transaction 계약을 바꾸지 않는다.
+ *
+ * 모든 값은 개인정보가 아닌 합성 문자열이다.
+ */
+
+const mockApprovalService = {
+  approveMembership: jest.fn(),
+  suspendMembership: jest.fn().mockResolvedValue(null),
+  withdrawMembership: jest.fn().mockResolvedValue(null),
+  reactivateMembership: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../../../../services/approval/MembershipApprovalService.js', () => ({
+  MembershipApprovalService: jest.fn().mockImplementation(() => mockApprovalService),
+}));
+jest.mock('../../../../modules/auth/services/role-assignment.service.js', () => ({
+  roleAssignmentService: { assignRole: jest.fn(), removeRole: jest.fn(), getRoleNames: jest.fn() },
+}));
+jest.mock('../../../../services/email.service.js', () => ({
+  emailService: { isServiceAvailable: () => false },
+}));
+jest.mock('../../../../services/NotificationService.js', () => ({
+  notificationService: { createNotification: jest.fn().mockResolvedValue(undefined) },
+}));
+jest.mock('../../../../modules/organization/services/organization-ops.service.js', () => ({
+  organizationOpsService: {
+    ensureOrganization: jest.fn().mockResolvedValue({ id: 'org-1' }),
+    addMember: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+jest.mock('@o4o/platform-core/store-identity', () => ({
+  StoreSlugService: jest.fn().mockImplementation(() => ({
+    findByStoreId: jest.fn().mockResolvedValue({ slug: 'x' }),
+    generateUniqueSlug: jest.fn(),
+    reserveSlug: jest.fn(),
+  })),
+}), { virtual: true });
+
+import { createMemberController } from '../member.controller.js';
+import { organizationOpsService } from '../../../../modules/organization/services/organization-ops.service.js';
+import { roleAssignmentService } from '../../../../modules/auth/services/role-assignment.service.js';
+
+const MEMBER_ID = '11111111-2222-4333-8444-555555555555';
+const USER_ID = '22222222-3333-4444-8555-666666666666';
+const OPERATOR_ID = '99999999-8888-4777-8666-555555555555';
+
+type Call = { sql: string; params: any[] };
+
+const norm = (sql: string) => String(sql).replace(/\s+/g, ' ').trim();
+
+interface HarnessOptions {
+  /** 회원의 이전 activity_type (기본: pharmacy_employee → 전이 발생) */
+  prevActivityType?: string;
+  businessInfo?: any;
+  /** organization 연락처 SELECT 응답 (미지정 = 신규 생성 직후 · 전 컬럼 비어 있음) */
+  orgRow?: any;
+  failOn?: RegExp;
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const calls: Call[] = [];
+  const state = { txStarted: 0, txCommitted: 0, txRolledBack: 0 };
+
+  const member = {
+    id: MEMBER_ID,
+    user_id: USER_ID,
+    status: 'active',
+    identity_status: 'active',
+    membership_type: 'pharmacist',
+    activity_type: options.prevActivityType ?? 'pharmacy_employee',
+    license_number: 'L-1',
+    pharmacy_name: 'TEST-PHARMACY',
+    pharmacy_address: null,
+    university_name: null,
+    student_year: null,
+  };
+
+  const businessInfo = options.businessInfo ?? { businessNumber: '123-45-67890' };
+
+  const runQuery = async (sql: string, params: any[] = []) => {
+    const n = norm(sql);
+    calls.push({ sql: n, params });
+    if (options.failOn && options.failOn.test(n)) throw new Error('INJECTED_FAILURE');
+    if (/SELECT "businessInfo" FROM users/i.test(n)) return [{ businessInfo }];
+    if (/SELECT address, address_detail, phone FROM organizations/i.test(n)) {
+      return options.orgRow === undefined
+        ? [{ address: null, address_detail: null, phone: null }]
+        : [options.orgRow];
+    }
+    if (/SELECT email, name FROM users/i.test(n)) return [{ email: null, name: null }];
+    return [];
+  };
+
+  const entityName = (e: any) => (typeof e === 'string' ? e : e?.name ?? String(e));
+  const manager = {
+    query: (sql: string, params?: any[]) => runQuery(sql, params ?? []),
+    findOne: async (entity: any) => (entityName(entity) === 'KpaMember' ? member : null),
+    save: async (_entity: any, value: any) => value,
+    create: (_entity: any, value: any) => value,
+  };
+
+  const dataSource: any = {
+    getRepository: (e: any) => ({
+      findOne: async () => (entityName(e) === 'KpaMember' ? member : null),
+      save: async (v: any) => v,
+      create: (v: any) => v,
+    }),
+    query: (sql: string, params?: any[]) => runQuery(sql, params ?? []),
+    transaction: async (cb: any) => {
+      state.txStarted += 1;
+      try {
+        const r = await cb(manager);
+        state.txCommitted += 1;
+        return r;
+      } catch (e) {
+        state.txRolledBack += 1;
+        throw e;
+      }
+    },
+  };
+
+  return { dataSource, calls, state, member };
+}
+
+async function patchInfo(h: ReturnType<typeof makeHarness>, body: Record<string, any>) {
+  const router: any = createMemberController(
+    h.dataSource,
+    ((_r: any, _s: any, next: any) => next()) as any,
+    (() => (_r: any, _s: any, next: any) => next()) as any,
+  );
+  const layer = router.stack.find((l: any) => l.route?.path === '/:id/info' && l.route?.methods?.patch);
+  const stack = layer.route.stack;
+  const handler = stack[stack.length - 1].handle;
+
+  const res: any = { statusCode: 200 };
+  res.status = jest.fn((c: number) => { res.statusCode = c; return res; });
+  res.json = jest.fn(() => res);
+
+  await handler(
+    { params: { id: MEMBER_ID }, body, user: { id: OPERATOR_ID, roles: ['kpa:operator'] } } as any,
+    res,
+  );
+  return res;
+}
+
+/** organizations 연락처 UPDATE 만 골라낸다. */
+const contactUpdates = (calls: Call[]) =>
+  calls.filter((c) => /^UPDATE organizations SET address =/i.test(c.sql));
+
+/** organizations 를 대상으로 하는 모든 write */
+const orgWrites = (calls: Call[]) =>
+  calls.filter((c) => /^(UPDATE|INSERT INTO|DELETE FROM) organizations\b/i.test(c.sql));
+
+const TO_OWNER = { activity_type: 'pharmacy_owner' };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('activity_type → pharmacy_owner — 신규 organization 초기화', () => {
+  it('canonical 키를 우선해 주소·우편번호·약국 전화를 채운다', async () => {
+    const h = makeHarness({
+      businessInfo: {
+        businessNumber: '123-45-67890',
+        address: 'CANON', address2: 'C2', zipCode: '11111',
+        businessAddress: 'LEGACY',
+        metadata: { pharmacy_phone: '02-000-0001' },
+        pharmacyPhone: '02-000-0002',
+      },
+    });
+    await patchInfo(h, TO_OWNER);
+
+    const updates = contactUpdates(h.calls);
+    expect(updates).toHaveLength(1);
+    const [address, detailJson, phone, orgId] = updates[0].params;
+    expect(address).toBe('CANON C2');
+    expect(JSON.parse(detailJson)).toEqual({ zipCode: '11111', baseAddress: 'CANON', detailAddress: 'C2' });
+    expect(phone).toBe('02-000-0001');
+    expect(orgId).toBe('org-1');
+  });
+
+  it('legacy 키만 있어도 주소가 organization 에 반영된다', async () => {
+    const h = makeHarness({
+      businessInfo: {
+        businessNumber: '123-45-67890',
+        businessAddress: 'LEGACY', businessAddressDetail: 'L2',
+        pharmacyPhone: '02-000-0002',
+      },
+    });
+    await patchInfo(h, TO_OWNER);
+
+    const [address, detailJson, phone] = contactUpdates(h.calls)[0].params;
+    expect(address).toBe('LEGACY L2');
+    expect(JSON.parse(detailJson)).toEqual({ baseAddress: 'LEGACY', detailAddress: 'L2' });
+    expect(phone).toBe('02-000-0002');
+  });
+
+  it('canonical 이 공백이면 유효한 legacy 값으로 fallback 한다', async () => {
+    const h = makeHarness({
+      businessInfo: {
+        businessNumber: '123-45-67890',
+        address: '   ', businessAddress: 'LEGACY',
+        metadata: { pharmacy_phone: '' }, pharmacyPhone: '02-000-0002',
+      },
+    });
+    await patchInfo(h, TO_OWNER);
+
+    const [address, detailJson, phone] = contactUpdates(h.calls)[0].params;
+    expect(address).toBe('LEGACY');
+    expect(JSON.parse(detailJson)).toEqual({ baseAddress: 'LEGACY' });
+    expect(phone).toBe('02-000-0002');
+  });
+
+  it('같은 요청에서 입력한 주소·약국 전화가 organization 초기화에 반영된다', async () => {
+    const h = makeHarness({ businessInfo: { businessNumber: '123-45-67890' } });
+    await patchInfo(h, {
+      ...TO_OWNER,
+      zipCode: '44444', address1: 'NEW-BASE', address2: 'NEW-DETAIL',
+      pharmacy_phone: '02-000-0044',
+    });
+
+    const [address, detailJson, phone] = contactUpdates(h.calls)[0].params;
+    expect(address).toBe('NEW-BASE NEW-DETAIL');
+    expect(JSON.parse(detailJson)).toEqual({
+      zipCode: '44444', baseAddress: 'NEW-BASE', detailAddress: 'NEW-DETAIL',
+    });
+    expect(phone).toBe('02-000-0044');
+  });
+
+  it('쓸 값이 없으면 연락처 UPDATE 자체를 생략한다', async () => {
+    const h = makeHarness({ businessInfo: { businessNumber: '123-45-67890' } });
+    await patchInfo(h, TO_OWNER);
+    expect(contactUpdates(h.calls)).toHaveLength(0);
+  });
+
+  it('대표 전화만 있으면 약국 전화를 만들지 않는다', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', phone: '02-999-9999' },
+    });
+    await patchInfo(h, TO_OWNER);
+    expect(contactUpdates(h.calls)).toHaveLength(0);
+  });
+
+  it('연락처 UPDATE 는 기존 값 우선 병합 SQL 을 유지한다 (이중 방어)', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON' },
+    });
+    await patchInfo(h, TO_OWNER);
+
+    const sql = contactUpdates(h.calls)[0].sql;
+    expect(sql).toContain("address = COALESCE(NULLIF(address, ''), $1)");
+    expect(sql).toContain("address_detail = $2::jsonb || COALESCE(address_detail, '{}'::jsonb)");
+    expect(sql).toContain("phone = COALESCE(NULLIF(phone, ''), $3)");
+  });
+});
+
+describe('activity_type → pharmacy_owner — 기존 organization 보존', () => {
+  it('기존 유효 값은 덮어쓰지 않는다', async () => {
+    const h = makeHarness({
+      businessInfo: {
+        businessNumber: '123-45-67890',
+        address: 'CANON', address2: 'C2', zipCode: '11111',
+        metadata: { pharmacy_phone: '02-000-0001' },
+      },
+      orgRow: {
+        address: 'OPERATOR-EDITED',
+        address_detail: { zipCode: '33333', baseAddress: 'OP-BASE', detailAddress: 'OP-DETAIL' },
+        phone: '02-777-7777',
+      },
+    });
+    await patchInfo(h, TO_OWNER);
+    expect(contactUpdates(h.calls)).toHaveLength(0);
+  });
+
+  it('중첩 키 보존 — 기존 baseAddress 는 지키고 비어 있는 zipCode 만 채운다', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON', zipCode: '11111' },
+      orgRow: { address: 'OPERATOR-EDITED', address_detail: { baseAddress: 'OP-BASE' }, phone: '02-777-7777' },
+    });
+    await patchInfo(h, TO_OWNER);
+
+    const [address, detailJson, phone] = contactUpdates(h.calls)[0].params;
+    expect(address).toBeNull();
+    expect(JSON.parse(detailJson)).toEqual({ zipCode: '11111' });
+    expect(phone).toBeNull();
+  });
+
+  it('기존 값이 공백이면 값 부재로 보고 채운다', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON', metadata: { pharmacy_phone: '02-000-0001' } },
+      orgRow: { address: '  ', address_detail: { baseAddress: '' }, phone: '' },
+    });
+    await patchInfo(h, TO_OWNER);
+
+    const [address, detailJson, phone] = contactUpdates(h.calls)[0].params;
+    expect(address).toBe('CANON');
+    expect(JSON.parse(detailJson)).toEqual({ baseAddress: 'CANON' });
+    expect(phone).toBe('02-000-0001');
+  });
+});
+
+describe('전이가 아닌 경우 — organizations 무변경', () => {
+  it('이미 pharmacy_owner 인 회원의 정보 수정은 organizations 를 건드리지 않는다', async () => {
+    const h = makeHarness({
+      prevActivityType: 'pharmacy_owner',
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON' },
+    });
+    await patchInfo(h, { ...TO_OWNER, address1: 'NEW-BASE' });
+
+    expect(orgWrites(h.calls)).toEqual([]);
+    expect(organizationOpsService.ensureOrganization).not.toHaveBeenCalled();
+  });
+
+  it('다른 activity type 으로의 변경은 organizations 를 건드리지 않는다', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON' },
+    });
+    await patchInfo(h, { activity_type: 'hospital' });
+    expect(orgWrites(h.calls)).toEqual([]);
+  });
+
+  it('직전 회귀: 사업자번호가 없으면 organization 생성도 연락처 write 도 하지 않는다', async () => {
+    const h = makeHarness({ businessInfo: { address: 'CANON' } });
+    const res = await patchInfo(h, TO_OWNER);
+
+    expect(organizationOpsService.ensureOrganization).not.toHaveBeenCalled();
+    expect(orgWrites(h.calls)).toEqual([]);
+    const payload = (res.json as jest.Mock).mock.calls[0][0];
+    expect((payload.warnings ?? []).join(' ')).toContain('사업자번호');
+  });
+});
+
+describe('후처리 경계 — 실패 격리', () => {
+  it('연락처 write 실패가 권한 부여·응답·transaction 계약을 바꾸지 않는다', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON' },
+      failOn: /^UPDATE organizations SET address =/i,
+    });
+    const res = await patchInfo(h, TO_OWNER);
+
+    expect(h.state.txCommitted).toBe(1);
+    expect(h.state.txRolledBack).toBe(0);
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    expect(roleAssignmentService.assignRole).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID, role: 'kpa:store_owner' }),
+    );
+    // 응답에는 권한 부여 실패 경고가 실리지 않는다 (연락처 동기화 실패는 격리된다).
+    const payload = (res.json as jest.Mock).mock.calls[0][0];
+    expect(payload.success).toBe(true);
+    expect(payload.warnings).toBeUndefined();
+  });
+
+  it('연락처 SELECT 실패도 권한 부여 결과를 error 로 바꾸지 않는다', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON' },
+      failOn: /^SELECT address, address_detail, phone FROM organizations/i,
+    });
+    const res = await patchInfo(h, TO_OWNER);
+
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    expect(roleAssignmentService.assignRole).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID, role: 'kpa:store_owner' }),
+    );
+    const payload = (res.json as jest.Mock).mock.calls[0][0];
+    expect(payload.success).toBe(true);
+    expect(payload.warnings).toBeUndefined();
+  });
+});

--- a/apps/api-server/src/routes/kpa/controllers/__tests__/member.controller.orgContactSync.test.ts
+++ b/apps/api-server/src/routes/kpa/controllers/__tests__/member.controller.orgContactSync.test.ts
@@ -1,0 +1,272 @@
+/**
+ * WO-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1
+ *
+ * PATCH /kpa/members/:id/status 의 organization 주소·약국 전화 동기화 계약을 고정한다.
+ *
+ * 고정 항목:
+ *   - pending → active (pharmacy_owner) 승인만 organization 연락처를 건드린다.
+ *   - suspended → active 재활성화는 organizations 에 **아무것도 쓰지 않는다** (검증 8).
+ *   - 기존 유효 값은 승인만으로 덮어쓰지 않는다 (검증 7).
+ *   - organization 동기화 실패는 승인 transaction 을 되돌리지 않는다 (검증 10 · 후처리 경계).
+ *
+ * 모든 값은 개인정보가 아닌 합성 문자열이다.
+ */
+
+const mockApprovalService = {
+  approveMembership: jest.fn(),
+  suspendMembership: jest.fn().mockResolvedValue(null),
+  withdrawMembership: jest.fn().mockResolvedValue(null),
+  reactivateMembership: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../../../../services/approval/MembershipApprovalService.js', () => ({
+  MembershipApprovalService: jest.fn().mockImplementation(() => mockApprovalService),
+}));
+jest.mock('../../../../modules/auth/services/role-assignment.service.js', () => ({
+  roleAssignmentService: { assignRole: jest.fn(), removeRole: jest.fn(), getRoleNames: jest.fn() },
+}));
+jest.mock('../../../../services/email.service.js', () => ({
+  emailService: { isServiceAvailable: () => false },
+}));
+jest.mock('../../../../services/NotificationService.js', () => ({
+  notificationService: { createNotification: jest.fn().mockResolvedValue(undefined) },
+}));
+jest.mock('../../../../modules/organization/services/organization-ops.service.js', () => ({
+  organizationOpsService: {
+    ensureOrganization: jest.fn().mockResolvedValue({ id: 'org-1' }),
+    addMember: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+jest.mock('@o4o/platform-core/store-identity', () => ({
+  StoreSlugService: jest.fn().mockImplementation(() => ({
+    findByStoreId: jest.fn().mockResolvedValue({ slug: 'x' }),
+    generateUniqueSlug: jest.fn(),
+    reserveSlug: jest.fn(),
+  })),
+}), { virtual: true });
+
+import { createMemberController } from '../member.controller.js';
+
+const MEMBER_ID = '11111111-2222-4333-8444-555555555555';
+const USER_ID = '22222222-3333-4444-8555-666666666666';
+const OPERATOR_ID = '99999999-8888-4777-8666-555555555555';
+
+type Call = { sql: string; params: any[] };
+
+const norm = (sql: string) => String(sql).replace(/\s+/g, ' ').trim();
+
+interface HarnessOptions {
+  status?: string;
+  businessInfo?: any;
+  /** 승인 시점의 organizations row (연락처 SELECT 응답) */
+  orgRow?: any;
+  /** 이 정규식에 걸리는 SQL 은 실패시킨다 */
+  failOn?: RegExp;
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const calls: Call[] = [];
+  const state = { txStarted: 0, txCommitted: 0, txRolledBack: 0 };
+
+  const member = {
+    id: MEMBER_ID,
+    user_id: USER_ID,
+    status: options.status ?? 'pending',
+    identity_status: 'active',
+    membership_type: 'pharmacist',
+    activity_type: 'pharmacy_owner',
+    license_number: 'L-1',
+    pharmacy_name: 'TEST-PHARMACY',
+    pharmacy_address: null,
+    university_name: null,
+    student_year: null,
+  };
+
+  const businessInfo = options.businessInfo ?? { businessNumber: '123-45-67890' };
+
+  const runQuery = async (sql: string, params: any[] = []) => {
+    const n = norm(sql);
+    calls.push({ sql: n, params });
+    if (options.failOn && options.failOn.test(n)) throw new Error('INJECTED_FAILURE');
+    if (/SELECT "businessInfo" FROM users/i.test(n)) return [{ businessInfo }];
+    if (/SELECT address, address_detail, phone FROM organizations/i.test(n)) {
+      return options.orgRow === undefined ? [{ address: null, address_detail: null, phone: null }] : [options.orgRow];
+    }
+    if (/SELECT email, name FROM users/i.test(n)) return [{ email: null, name: null }];
+    return [];
+  };
+
+  const entityName = (e: any) => (typeof e === 'string' ? e : e?.name ?? String(e));
+  const manager = {
+    query: (sql: string, params?: any[]) => runQuery(sql, params ?? []),
+    findOne: async (entity: any) => (entityName(entity) === 'KpaMember' ? member : null),
+    save: async (_entity: any, value: any) => value,
+    create: (_entity: any, value: any) => value,
+  };
+
+  const dataSource: any = {
+    getRepository: (e: any) => ({
+      findOne: async () => (entityName(e) === 'KpaMember' ? member : null),
+      save: async (v: any) => v,
+      create: (v: any) => v,
+    }),
+    query: (sql: string, params?: any[]) => runQuery(sql, params ?? []),
+    transaction: async (cb: any) => {
+      state.txStarted += 1;
+      try {
+        const r = await cb(manager);
+        state.txCommitted += 1;
+        return r;
+      } catch (e) {
+        state.txRolledBack += 1;
+        throw e;
+      }
+    },
+  };
+
+  return { dataSource, calls, state, member };
+}
+
+async function patchStatus(h: ReturnType<typeof makeHarness>, newStatus: string) {
+  const router: any = createMemberController(
+    h.dataSource,
+    ((_r: any, _s: any, next: any) => next()) as any,
+    (() => (_r: any, _s: any, next: any) => next()) as any,
+  );
+  const layer = router.stack.find((l: any) => l.route?.path === '/:id/status' && l.route?.methods?.patch);
+  const stack = layer.route.stack;
+  const handler = stack[stack.length - 1].handle;
+
+  const res: any = { status: jest.fn(() => res), json: jest.fn(() => res) };
+  await handler(
+    { params: { id: MEMBER_ID }, body: { status: newStatus }, user: { id: OPERATOR_ID, roles: ['kpa:operator'] } } as any,
+    res,
+  );
+  return res;
+}
+
+/** organizations 연락처 UPDATE (주소/전화) 호출만 골라낸다. */
+const contactUpdates = (calls: Call[]) =>
+  calls.filter((c) => /^UPDATE organizations SET address =/i.test(c.sql));
+
+/** organizations 를 대상으로 하는 모든 write */
+const orgWrites = (calls: Call[]) =>
+  calls.filter((c) => /^(UPDATE|INSERT INTO|DELETE FROM) organizations\b/i.test(c.sql));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('승인(pending → active) — organization 연락처 초기화', () => {
+  it('canonical 키를 우선해 주소·우편번호·약국 전화를 채운다', async () => {
+    const h = makeHarness({
+      businessInfo: {
+        businessNumber: '123-45-67890',
+        address: 'CANON', address2: 'C2', zipCode: '11111',
+        businessAddress: 'LEGACY',
+        metadata: { pharmacy_phone: '02-000-0001' },
+        pharmacyPhone: '02-000-0002',
+      },
+    });
+    await patchStatus(h, 'active');
+
+    const updates = contactUpdates(h.calls);
+    expect(updates).toHaveLength(1);
+    const [address, detailJson, phone] = updates[0].params;
+    expect(address).toBe('CANON C2');
+    expect(JSON.parse(detailJson)).toEqual({ zipCode: '11111', baseAddress: 'CANON', detailAddress: 'C2' });
+    expect(phone).toBe('02-000-0001');
+  });
+
+  it('legacy 키만 있어도 주소가 organization 에 반영된다', async () => {
+    const h = makeHarness({
+      businessInfo: {
+        businessNumber: '123-45-67890',
+        businessAddress: 'LEGACY', businessAddressDetail: 'L2',
+        pharmacyPhone: '02-000-0002',
+      },
+    });
+    await patchStatus(h, 'active');
+
+    const [address, detailJson, phone] = contactUpdates(h.calls)[0].params;
+    expect(address).toBe('LEGACY L2');
+    expect(JSON.parse(detailJson)).toEqual({ baseAddress: 'LEGACY', detailAddress: 'L2' });
+    expect(phone).toBe('02-000-0002');
+  });
+
+  it('대표 전화만 있으면 약국 전화를 만들지 않는다', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', phone: '02-999-9999' },
+    });
+    await patchStatus(h, 'active');
+    expect(contactUpdates(h.calls)).toHaveLength(0);
+  });
+
+  it('7) 기존 organization 의 유효한 값은 승인만으로 덮어쓰지 않는다', async () => {
+    const h = makeHarness({
+      businessInfo: {
+        businessNumber: '123-45-67890',
+        address: 'CANON', zipCode: '11111', metadata: { pharmacy_phone: '02-000-0001' },
+      },
+      orgRow: {
+        address: 'OPERATOR-EDITED',
+        address_detail: { zipCode: '33333', baseAddress: 'OP-BASE', detailAddress: 'OP-DETAIL' },
+        phone: '02-777-7777',
+      },
+    });
+    await patchStatus(h, 'active');
+    expect(contactUpdates(h.calls)).toHaveLength(0);
+  });
+
+  it('기존 organization 에서 비어 있는 항목만 보완한다', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON', zipCode: '11111' },
+      orgRow: { address: 'OPERATOR-EDITED', address_detail: { baseAddress: 'OP-BASE' }, phone: '02-777-7777' },
+    });
+    await patchStatus(h, 'active');
+
+    const [address, detailJson, phone] = contactUpdates(h.calls)[0].params;
+    expect(address).toBeNull();
+    expect(JSON.parse(detailJson)).toEqual({ zipCode: '11111' });
+    expect(phone).toBeNull();
+  });
+
+  it('연락처 UPDATE 는 기존 값 우선 병합 SQL 을 유지한다 (이중 방어)', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON' },
+    });
+    await patchStatus(h, 'active');
+    const sql = contactUpdates(h.calls)[0].sql;
+    expect(sql).toContain("address = COALESCE(NULLIF(address, ''), $1)");
+    expect(sql).toContain("address_detail = $2::jsonb || COALESCE(address_detail, '{}'::jsonb)");
+    expect(sql).toContain("phone = COALESCE(NULLIF(phone, ''), $3)");
+  });
+});
+
+describe('재활성화(suspended → active) — organization 무변경', () => {
+  it('8) organizations 에 어떤 write 도 발생하지 않는다', async () => {
+    const h = makeHarness({
+      status: 'suspended',
+      businessInfo: {
+        businessNumber: '123-45-67890', address: 'CANON', metadata: { pharmacy_phone: '02-000-0001' },
+      },
+    });
+    await patchStatus(h, 'active');
+    expect(orgWrites(h.calls)).toEqual([]);
+    expect(mockApprovalService.reactivateMembership).toHaveBeenCalled();
+  });
+});
+
+describe('후처리 경계 — 실패 격리', () => {
+  it('10) organization 연락처 write 실패가 승인 transaction 을 되돌리지 않는다', async () => {
+    const h = makeHarness({
+      businessInfo: { businessNumber: '123-45-67890', address: 'CANON' },
+      failOn: /^UPDATE organizations SET address =/i,
+    });
+    const res = await patchStatus(h, 'active');
+
+    expect(h.state.txCommitted).toBe(1);
+    expect(h.state.txRolledBack).toBe(0);
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    // 승인 자체의 후속 단계(kpa_members.organization_id 연결)는 계속 진행된다.
+    expect(h.calls.some((c) => /^UPDATE kpa_members SET organization_id/i.test(c.sql))).toBe(true);
+  });
+});

--- a/apps/api-server/src/routes/kpa/controllers/member.controller.ts
+++ b/apps/api-server/src/routes/kpa/controllers/member.controller.ts
@@ -1455,6 +1455,35 @@ export function createMemberController(
                 role: 'kpa:store_owner',
                 assignedBy: (req as any).user?.id,
               });
+
+              // WO-O4O-KPA-ACTIVITY-TYPE-PHARMACY-OWNER-ORGANIZATION-CONTACT-ALIGNMENT-V1
+              //   승인 경로(PATCH /:id/status) 와 동일한 주소·약국 전화 초기화 계약을 적용한다.
+              //   - 신규 organization: resolver 결과로 초기화.
+              //   - 기존 organization: 유효한 값은 덮어쓰지 않고 비어 있는 항목만 보완.
+              //   - 대표 전화(businessInfo.phone) 는 약국 전화로 승격하지 않는다.
+              //   prevBiz 는 이 요청의 businessInfo patch 가 반영된 "갱신 후" 값이다.
+              //   권한 부여와 독립된 try/catch — 연락처 동기화 실패가 store_owner 부여 결과를
+              //   'error' 로 바꾸지 않는다 (기존 후처리 계약 유지).
+              try {
+                const [orgRow] = await dataSource.query(
+                  `SELECT address, address_detail, phone FROM organizations WHERE id = $1 LIMIT 1`,
+                  [orgResult.id],
+                );
+                const contactPlan = planKpaOrganizationContactSync(prevBiz, orgRow ?? null);
+                if (contactPlan.hasChanges) {
+                  await dataSource.query(
+                    `UPDATE organizations SET
+                       address = COALESCE(NULLIF(address, ''), $1),
+                       address_detail = $2::jsonb || COALESCE(address_detail, '{}'::jsonb),
+                       phone = COALESCE(NULLIF(phone, ''), $3)
+                     WHERE id = $4`,
+                    [contactPlan.address, JSON.stringify(contactPlan.addressDetail ?? {}), contactPlan.phone, orgResult.id],
+                  );
+                }
+              } catch (orgContactErr) {
+                console.error('[KPA Operator] Organization contact sync failed (non-blocking):', orgContactErr);
+              }
+
               changes._store_owner_activated = true;
             }
           } catch (activateErr) {

--- a/apps/api-server/src/routes/kpa/controllers/member.controller.ts
+++ b/apps/api-server/src/routes/kpa/controllers/member.controller.ts
@@ -22,6 +22,7 @@ import { organizationOpsService } from '../../../modules/organization/services/o
 import { StoreSlugService } from '@o4o/platform-core/store-identity';
 // WO-O4O-KPA-BUSINESSINFO-KEY-READ-ALIGNMENT-V1: businessInfo 주소·약국 전화 read 정렬 (read-only)
 import { resolveKpaBusinessContact } from '../shared/businessInfoRead.js';
+import { planKpaOrganizationContactSync } from '../shared/organizationContactSync.js';
 // WO-O4O-KPA-PROFILE-WRITE-JSONB-CONCAT-CONVERGENCE-V1: businessInfo 부분 갱신 (스냅샷 되쓰기 제거)
 import type { BusinessInfoPatch } from '../../../utils/business-info-write.js';
 import { applyBusinessInfoPatch, buildBusinessInfoUpdateStatement } from '../../../utils/business-info-write.js';
@@ -770,47 +771,52 @@ export function createMemberController(
               // 1-b. WO-O4O-KPA-STORE-INFO-PHARMACY-OWNER-DATA-FIX-V1:
               //   organizations 테이블에 약국 정보 동기화 (NULL 또는 빈 값만 채움, 기존 값 보존)
               //   소스: users.businessInfo (경로 B 사용자는 kpa_pharmacy_requests 없음)
+              //
+              // WO-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1:
+              //   주소·약국 전화의 원천 키 선택을 공통 resolver 로 수렴.
+              //   기존 구현의 3가지 불일치를 교정한다.
+              //     ① 주소가 `storeAddress` 우선이라 운영자가 고친 최신 `address` 가 밀렸다.
+              //     ② `businessAddress` / `businessAddressDetail` (가입 경로 키) fallback 이 없어
+              //        가입 시 입력한 주소가 organization 에 전혀 반영되지 않았다.
+              //     ③ 약국 전화가 `pharmacyPhone` (공통 운영자 콘솔 키) 을 못 보고,
+              //        대신 대표 전화 `biz.phone` 로 fallback 해 두 의미를 합쳤다.
+              //   우편번호는 지금까지 어디에도 기록되지 않아 address_detail.zipCode 로 채운다.
               try {
                 const orgMeta: Record<string, string | null> = {};
                 if (biz.taxInvoiceEmail) orgMeta.taxInvoiceEmail = biz.taxInvoiceEmail;
                 if (biz.ceoName) orgMeta.ceoName = biz.ceoName;
                 if (biz.contactName) orgMeta.contactName = biz.contactName;
                 if (biz.managerPhone) orgMeta.managerPhone = biz.managerPhone;
-                // pharmacy_phone 우선, 없으면 대표 phone
-                const phoneValue = (biz.metadata?.pharmacy_phone as string | undefined) || biz.phone || null;
                 await dataSource.query(
                   `UPDATE organizations SET
-                     phone = COALESCE(NULLIF(phone, ''), $1),
-                     business_number = COALESCE(NULLIF(business_number, ''), $2),
-                     metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb
-                   WHERE id = $4`,
+                     business_number = COALESCE(NULLIF(business_number, ''), $1),
+                     metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb
+                   WHERE id = $3`,
                   [
-                    phoneValue,
                     biz.businessNumber || null,
                     JSON.stringify(orgMeta),
                     orgResult.id,
                   ],
                 );
-                // 구조화 주소 (storeAddress 우선, 없으면 레거시 address)
-                if (biz.storeAddress?.baseAddress) {
+
+                // 주소·약국 전화: 현재 organization 값을 먼저 읽어 "빈 칸만" 채운다.
+                //   기존 유효 값 보존이 계약이므로 SQL 의 COALESCE 가드도 함께 유지한다 (이중 방어).
+                const [orgRow] = await dataSource.query(
+                  `SELECT address, address_detail, phone FROM organizations WHERE id = $1 LIMIT 1`,
+                  [orgResult.id],
+                );
+                const contactPlan = planKpaOrganizationContactSync(biz, orgRow ?? null);
+                if (contactPlan.hasChanges) {
                   await dataSource.query(
                     `UPDATE organizations SET
                        address = COALESCE(NULLIF(address, ''), $1),
-                       address_detail = COALESCE(address_detail, $2::jsonb)
-                     WHERE id = $3`,
+                       address_detail = $2::jsonb || COALESCE(address_detail, '{}'::jsonb),
+                       phone = COALESCE(NULLIF(phone, ''), $3)
+                     WHERE id = $4`,
                     [
-                      [biz.storeAddress.baseAddress, biz.storeAddress.detailAddress].filter(Boolean).join(' '),
-                      JSON.stringify(biz.storeAddress),
-                      orgResult.id,
-                    ],
-                  );
-                } else if (biz.address) {
-                  await dataSource.query(
-                    `UPDATE organizations SET
-                       address = COALESCE(NULLIF(address, ''), $1)
-                     WHERE id = $2`,
-                    [
-                      [biz.address, biz.address2].filter(Boolean).join(' ').trim(),
+                      contactPlan.address,
+                      JSON.stringify(contactPlan.addressDetail ?? {}),
+                      contactPlan.phone,
                       orgResult.id,
                     ],
                   );

--- a/apps/api-server/src/routes/kpa/shared/__tests__/organizationContactSync.test.ts
+++ b/apps/api-server/src/routes/kpa/shared/__tests__/organizationContactSync.test.ts
@@ -1,0 +1,142 @@
+/**
+ * WO-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1
+ *
+ * 승인 시 `users.businessInfo` → `organizations` 주소·약국 전화 write plan 계약.
+ * WO 검증 항목 1~8 을 이 파일에서 고정한다.
+ * 모든 값은 개인정보가 아닌 합성 문자열이다.
+ */
+
+import { planKpaOrganizationContactSync } from '../organizationContactSync.js';
+
+/** 신규 생성 직후 organization — 전 컬럼 비어 있음. */
+const NEW_ORG = { address: null, address_detail: null, phone: null };
+
+describe('planKpaOrganizationContactSync — 신규 organization 초기화', () => {
+  it('1) canonical 키만 있는 신규 승인', () => {
+    const plan = planKpaOrganizationContactSync(
+      { address: 'CANON', address2: 'C2', zipCode: '11111', metadata: { pharmacy_phone: '02-000-0001' } },
+      NEW_ORG,
+    );
+    expect(plan.address).toBe('CANON C2');
+    expect(plan.addressDetail).toEqual({ zipCode: '11111', baseAddress: 'CANON', detailAddress: 'C2' });
+    expect(plan.phone).toBe('02-000-0001');
+    expect(plan.hasChanges).toBe(true);
+  });
+
+  it('2) legacy 키만 있는 신규 승인', () => {
+    const plan = planKpaOrganizationContactSync(
+      { businessAddress: 'LEGACY', businessAddressDetail: 'L2', pharmacyPhone: '02-000-0002' },
+      NEW_ORG,
+    );
+    expect(plan.address).toBe('LEGACY L2');
+    expect(plan.addressDetail).toEqual({ baseAddress: 'LEGACY', detailAddress: 'L2' });
+    expect(plan.phone).toBe('02-000-0002');
+  });
+
+  it('3) 양쪽 값이 다르면 canonical 우선', () => {
+    const plan = planKpaOrganizationContactSync(
+      {
+        address: 'CANON', businessAddress: 'LEGACY',
+        metadata: { pharmacy_phone: '02-000-0001' }, pharmacyPhone: '02-000-0002',
+      },
+      NEW_ORG,
+    );
+    expect(plan.address).toBe('CANON');
+    expect(plan.addressDetail).toEqual({ baseAddress: 'CANON' });
+    expect(plan.phone).toBe('02-000-0001');
+  });
+
+  it('4) canonical 이 공백이면 유효한 legacy 값을 쓴다', () => {
+    const plan = planKpaOrganizationContactSync(
+      {
+        address: '   ', businessAddress: 'LEGACY',
+        address2: '', businessAddressDetail: 'L2',
+        metadata: { pharmacy_phone: '' }, pharmacyPhone: '02-000-0002',
+      },
+      NEW_ORG,
+    );
+    expect(plan.address).toBe('LEGACY L2');
+    expect(plan.addressDetail).toEqual({ baseAddress: 'LEGACY', detailAddress: 'L2' });
+    expect(plan.phone).toBe('02-000-0002');
+  });
+
+  it('5) 값이 없으면 임의 값을 만들지 않는다', () => {
+    const plan = planKpaOrganizationContactSync({ businessNumber: '000-00-00000' }, NEW_ORG);
+    expect(plan).toEqual({ address: null, addressDetail: null, phone: null, hasChanges: false });
+  });
+
+  it('5-b) businessInfo 자체가 없어도 안전하다', () => {
+    expect(planKpaOrganizationContactSync(null, NEW_ORG).hasChanges).toBe(false);
+    expect(planKpaOrganizationContactSync(undefined, null).hasChanges).toBe(false);
+  });
+
+  it('6) storeAddress 만 있는 회원도 우편번호까지 초기화된다', () => {
+    const plan = planKpaOrganizationContactSync(
+      { storeAddress: { zipCode: '22222', baseAddress: 'STORE', detailAddress: 'S2' } },
+      NEW_ORG,
+    );
+    expect(plan.address).toBe('STORE S2');
+    expect(plan.addressDetail).toEqual({ zipCode: '22222', baseAddress: 'STORE', detailAddress: 'S2' });
+  });
+
+  it('대표 전화(phone)는 약국 전화로 승격되지 않는다', () => {
+    const plan = planKpaOrganizationContactSync({ phone: '02-999-9999' }, NEW_ORG);
+    expect(plan.phone).toBeNull();
+    expect(plan.hasChanges).toBe(false);
+  });
+});
+
+describe('planKpaOrganizationContactSync — 기존 organization 보존', () => {
+  it('7) 기존 유효 값은 덮어쓰지 않는다', () => {
+    const plan = planKpaOrganizationContactSync(
+      { address: 'CANON', address2: 'C2', zipCode: '11111', metadata: { pharmacy_phone: '02-000-0001' } },
+      {
+        address: 'OPERATOR-EDITED',
+        address_detail: { zipCode: '33333', baseAddress: 'OP-BASE', detailAddress: 'OP-DETAIL' },
+        phone: '02-777-7777',
+      },
+    );
+    expect(plan).toEqual({ address: null, addressDetail: null, phone: null, hasChanges: false });
+  });
+
+  it('기존 값이 공백이면 값 부재로 보고 채운다', () => {
+    const plan = planKpaOrganizationContactSync(
+      { address: 'CANON', metadata: { pharmacy_phone: '02-000-0001' } },
+      { address: '  ', address_detail: { baseAddress: '' }, phone: '' },
+    );
+    expect(plan.address).toBe('CANON');
+    expect(plan.addressDetail).toEqual({ baseAddress: 'CANON' });
+    expect(plan.phone).toBe('02-000-0001');
+  });
+
+  it('키 단위 보완 — 기존 baseAddress 는 지키고 비어 있는 zipCode 만 채운다', () => {
+    const plan = planKpaOrganizationContactSync(
+      { address: 'CANON', zipCode: '11111' },
+      { address: 'OPERATOR-EDITED', address_detail: { baseAddress: 'OP-BASE' }, phone: '02-777-7777' },
+    );
+    expect(plan.address).toBeNull();
+    expect(plan.addressDetail).toEqual({ zipCode: '11111' });
+    expect(plan.phone).toBeNull();
+    expect(plan.hasChanges).toBe(true);
+  });
+
+  it('약국 전화만 비어 있으면 전화만 채운다', () => {
+    const plan = planKpaOrganizationContactSync(
+      { address: 'CANON', pharmacyPhone: '02-000-0002' },
+      { address: 'OP', address_detail: { zipCode: '3', baseAddress: 'B', detailAddress: 'D' }, phone: null },
+    );
+    expect(plan.address).toBeNull();
+    expect(plan.addressDetail).toBeNull();
+    expect(plan.phone).toBe('02-000-0002');
+  });
+
+  it('원본 businessInfo 와 기존 row 를 변경하지 않는다 (read-only)', () => {
+    const biz = { address: 'CANON', zipCode: '11111' };
+    const existing = { address: null, address_detail: { baseAddress: 'OP' }, phone: null };
+    const bizSnapshot = JSON.stringify(biz);
+    const existingSnapshot = JSON.stringify(existing);
+    planKpaOrganizationContactSync(biz, existing);
+    expect(JSON.stringify(biz)).toBe(bizSnapshot);
+    expect(JSON.stringify(existing)).toBe(existingSnapshot);
+  });
+});

--- a/apps/api-server/src/routes/kpa/shared/organizationContactSync.ts
+++ b/apps/api-server/src/routes/kpa/shared/organizationContactSync.ts
@@ -1,0 +1,113 @@
+/**
+ * WO-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1
+ *
+ * KPA 회원 승인 시 `users.businessInfo` → `organizations` 로 **주소 · 약국 전화**를
+ * 옮기는 write 계약. 읽기 키 해석은 직전 WO 의 공통 resolver
+ * (`businessInfoRead.resolveKpaBusinessContact`) 를 그대로 재사용한다.
+ *
+ * 이 모듈이 정하는 것은 "**어떤 값을 쓸지**" 가 아니라 "**써도 되는지**" 이다.
+ *
+ * 계약:
+ *   1. 신규 organization 초기화 — 대상 컬럼이 비어 있으면 resolver 값으로 채운다.
+ *   2. 기존 organization 보완 — **유효한 기존 값은 절대 덮어쓰지 않는다.**
+ *      운영자가 `PATCH /operator/members/:userId` · 매장 정보 화면에서 직접 고친 값이
+ *      승인·재활성화만으로 가입 시점 값으로 되돌아가면 안 된다.
+ *   3. 공백(`''` · 공백문자열)은 **값 부재**로 취급한다 — 기존 컬럼이 공백이면 채우고,
+ *      resolver 값이 공백이면 쓰지 않는다.
+ *   4. 채울 값이 없으면 **임의 값을 만들지 않는다** (빈 문자열·placeholder write 금지).
+ *   5. 대표 전화(`businessInfo.phone`)는 **약국 전화가 아니다.** 약국 전화 컬럼에 섞지 않는다.
+ *      (기존 구현은 `metadata.pharmacy_phone || biz.phone` 로 두 의미를 합쳤다 — 제거.)
+ *
+ * 범위 밖: `business_number` · `metadata`(taxInvoiceEmail 등) write 는 기존 동작을 유지한다.
+ * 이 모듈은 순수 함수이며 DB 접근·migration·backfill 을 수행하지 않는다.
+ */
+
+import { resolveKpaBusinessContact } from './businessInfoRead.js';
+
+/** 값이 실제로 존재하는 문자열일 때만 채택한다 (공백 = 부재). */
+function present(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+/** `organizations` 에서 읽어온 현재 연락처 상태 (컬럼 원문). */
+export interface ExistingOrganizationContact {
+  address?: unknown;
+  /** jsonb — `{ zipCode, baseAddress, detailAddress }` */
+  address_detail?: unknown;
+  phone?: unknown;
+}
+
+/** 구조화 주소 (organizations.address_detail 및 businessInfo.storeAddress 공용 shape). */
+export interface OrganizationAddressDetail {
+  zipCode?: string;
+  baseAddress?: string;
+  detailAddress?: string;
+}
+
+export interface OrganizationContactSyncPlan {
+  /** 채울 값. null = **쓰지 않는다** (기존 값 보존 또는 원천 부재). */
+  address: string | null;
+  addressDetail: OrganizationAddressDetail | null;
+  phone: string | null;
+  /** 셋 중 하나라도 쓸 것이 있는가 — false 면 UPDATE 자체를 생략한다. */
+  hasChanges: boolean;
+}
+
+const EMPTY_PLAN: OrganizationContactSyncPlan = {
+  address: null,
+  addressDetail: null,
+  phone: null,
+  hasChanges: false,
+};
+
+/**
+ * 승인 시점의 `businessInfo` 와 현재 organization 상태로부터 write plan 을 만든다.
+ *
+ * @param businessInfo `users.businessInfo` 원문
+ * @param existing     현재 organization row (신규 생성 직후면 전 컬럼 비어 있음 / 조회 실패면 null)
+ */
+export function planKpaOrganizationContactSync(
+  businessInfo: unknown,
+  existing: ExistingOrganizationContact | null,
+): OrganizationContactSyncPlan {
+  const contact = resolveKpaBusinessContact(businessInfo);
+
+  const existingAddress = present(existing?.address);
+  const existingPhone = present(existing?.phone);
+  const existingDetailRaw =
+    existing?.address_detail && typeof existing.address_detail === 'object'
+      ? (existing.address_detail as Record<string, unknown>)
+      : null;
+
+  // ── 주소 (scalar) ────────────────────────────────────────────────
+  // organizations.address 는 "기본 + 상세" 를 합친 표시용 단일 문자열이다 (기존 계약 유지).
+  const composedAddress = [contact.address, contact.address2]
+    .filter((v): v is string => typeof v === 'string' && v.trim() !== '')
+    .join(' ')
+    .trim();
+  const address = existingAddress ? null : (composedAddress || null);
+
+  // ── 주소 (구조화) ────────────────────────────────────────────────
+  // 키 단위 보완: 기존 유효 값이 있으면 그 키는 건드리지 않는다.
+  const resolvedDetail: OrganizationAddressDetail = {};
+  const zipCode = present(existingDetailRaw?.zipCode) ? null : contact.zipCode;
+  const baseAddress = present(existingDetailRaw?.baseAddress) ? null : contact.address;
+  const detailAddress = present(existingDetailRaw?.detailAddress) ? null : contact.address2;
+  if (zipCode) resolvedDetail.zipCode = zipCode;
+  if (baseAddress) resolvedDetail.baseAddress = baseAddress;
+  if (detailAddress) resolvedDetail.detailAddress = detailAddress;
+  const addressDetail = Object.keys(resolvedDetail).length > 0 ? resolvedDetail : null;
+
+  // ── 약국 전화 ────────────────────────────────────────────────────
+  // 대표 전화(businessInfo.phone) 로의 fallback 은 두지 않는다 (의미가 다르다).
+  const phone = existingPhone ? null : contact.pharmacyPhone;
+
+  const plan: OrganizationContactSyncPlan = {
+    address,
+    addressDetail,
+    phone,
+    hasChanges: Boolean(address || addressDetail || phone),
+  };
+
+  return plan.hasChanges ? plan : { ...EMPTY_PLAN };
+}

--- a/docs/checks/CHECK-O4O-KPA-ACTIVITY-TYPE-PHARMACY-OWNER-ORGANIZATION-CONTACT-ALIGNMENT-V1.md
+++ b/docs/checks/CHECK-O4O-KPA-ACTIVITY-TYPE-PHARMACY-OWNER-ORGANIZATION-CONTACT-ALIGNMENT-V1.md
@@ -1,0 +1,116 @@
+# CHECK-O4O-KPA-ACTIVITY-TYPE-PHARMACY-OWNER-ORGANIZATION-CONTACT-ALIGNMENT-V1
+
+- **WO**: WO-O4O-KPA-ACTIVITY-TYPE-PHARMACY-OWNER-ORGANIZATION-CONTACT-ALIGNMENT-V1
+- **일자**: 2026-08-13
+- **선행**: `192086556` (WO-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1) · `695b96cdb` (BUSINESSINFO-KEY-READ-ALIGNMENT)
+- **판정**: PASS
+
+---
+
+## 1. 문제 확정
+
+KPA 에서 `organizations` 를 만드는 경로는 두 개다.
+
+| 경로 | 진입 | 직전 상태 |
+|---|---|---|
+| A 승인 | `PATCH /kpa/members/:id/status` (pending → active) | `192086556` 로 주소·약국 전화 초기화 정렬 완료 |
+| B 활동유형 전환 | `PATCH /kpa/members/:id/info` (`activity_type` → `pharmacy_owner`) | **연락처 write 전무** |
+
+경로 B 는 `organizationOpsService.ensureOrganization()` → `kpa_members.organization_id` 연결 →
+`addMember(role:'owner')` → `assignRole('kpa:store_owner')` 만 수행하고
+`address` · `address_detail` · `phone` 에 아무것도 쓰지 않았다.
+같은 약국이 어느 경로로 organization 을 얻었는지에 따라 연락처 유무가 갈렸다.
+
+`member.controller.ts:1435` (경로 B) 와 `:763` (경로 A) 이 동일한 `kpa-pharm-{사업자번호}` org code 를
+쓰므로, 두 경로는 같은 organization 을 만들면서 다른 계약을 갖고 있었다.
+
+---
+
+## 2. 수정 내용
+
+`apps/api-server/src/routes/kpa/controllers/member.controller.ts` — 경로 B 의
+`assignRole('kpa:store_owner')` 직후에 경로 A 와 동일한 연락처 초기화를 추가했다.
+
+```
+SELECT address, address_detail, phone FROM organizations WHERE id = $1 LIMIT 1
+→ planKpaOrganizationContactSync(prevBiz, orgRow ?? null)
+→ hasChanges 일 때만
+  UPDATE organizations SET
+    address        = COALESCE(NULLIF(address, ''), $1),
+    address_detail = $2::jsonb || COALESCE(address_detail, '{}'::jsonb),
+    phone          = COALESCE(NULLIF(phone, ''), $3)
+  WHERE id = $4
+```
+
+- 계약 판단은 선행 WO 의 순수 함수 `planKpaOrganizationContactSync` 를 **그대로 재사용**한다.
+  이 WO 는 공통 모듈(`shared/organizationContactSync.ts` · `shared/businessInfoRead.ts`)을 **수정하지 않았다.**
+- 소스 객체는 `prevBiz` 다. 이름과 달리 이 시점의 `prevBiz` 는 같은 요청의
+  `businessInfo` patch 가 반영된 **갱신 후** 값이다(`member.controller.ts:1356`).
+  따라서 이번 요청에서 운영자가 입력한 주소·약국 전화가 그대로 초기화에 쓰인다.
+- 연락처 동기화는 권한 부여와 **분리된 try/catch** 안에 둔다.
+  기존 바깥 catch 는 실패 시 `changes._store_owner_activation = 'error'` 와 경고를 남기는데,
+  연락처 동기화 실패가 권한 부여 결과 표기를 바꾸면 기존 후처리 계약이 달라진다. 이를 막는다.
+
+---
+
+## 3. 계약 준수 확인
+
+| 원칙 | 확인 |
+|---|---|
+| 신규 organization 은 resolver 결과로 초기화 | canonical / legacy / `storeAddress` fallback 모두 반영 |
+| 기존 organization 의 유효한 값 비덮어쓰기 | plan 에서 null + SQL `COALESCE(NULLIF(...))` 이중 방어 |
+| 대표 전화와 약국 전용 전화 미결합 | `businessInfo.phone` fallback 없음 (plan 계약) |
+| 권한·응답·transaction·후처리 계약 불변 | `_store_owner_activated` · warnings · 응답 shape · tx 경계 무변경 |
+| 다른 activity type · 다른 서비스 무영향 | 전이 조건(`activity_type==='pharmacy_owner' && prev!==`) 안에서만 실행 |
+| migration · backfill · 운영 DB write · 배포 없음 | 코드/테스트/문서만 변경 |
+
+---
+
+## 4. 검증
+
+`apps/api-server` 기준.
+
+| 항목 | 결과 |
+|---|---|
+| `npx jest src/routes/kpa` | **8 suites / 101 tests PASS** |
+| 신규 `member.controller.infoOrgContactSync.test.ts` | 15 tests PASS |
+| `npx tsc --noEmit` | 오류 0 |
+
+신규 테스트가 고정한 것:
+
+- 신규 org — canonical 우선(주소·우편번호·약국 전화), legacy 전용, canonical 공백 → legacy fallback,
+  **같은 요청에서 입력한 주소·전화 반영**, 쓸 값 없으면 UPDATE 생략, 대표 전화만 있으면 약국 전화 미생성,
+  병합 SQL shape 유지
+- 기존 org — 유효 값 비덮어쓰기, **중첩 키 보존**(기존 `baseAddress` 유지 · 빈 `zipCode` 만 보완),
+  기존 공백은 부재로 보고 보완
+- 무변경 — 이미 `pharmacy_owner` 인 회원 수정 · 다른 activity type 전환은 `organizations` write 0
+- 직전 회귀 — 사업자번호 부재 시 org 생성도 연락처 write 도 하지 않고 경고만 남긴다
+- 실패 격리 — 연락처 UPDATE 실패 / SELECT 실패 모두 tx commit 1 · rollback 0 · 500 아님 ·
+  `kpa:store_owner` 부여 정상 · 경고 미발생
+
+운영 DB write · smoke · 배포는 WO 제외 범위이므로 수행하지 않았다. 개인정보는 조회·기록하지 않았다.
+
+---
+
+## 5. 변경 파일
+
+**코드 2개(소스 1 · 테스트 1) · 문서 1개, 총 3개**
+
+| 파일 | 구분 |
+|---|---|
+| `apps/api-server/src/routes/kpa/controllers/member.controller.ts` | 수정 |
+| `apps/api-server/src/routes/kpa/controllers/__tests__/member.controller.infoOrgContactSync.test.ts` | 신규 |
+| `docs/checks/CHECK-O4O-KPA-ACTIVITY-TYPE-PHARMACY-OWNER-ORGANIZATION-CONTACT-ALIGNMENT-V1.md` | 신규 |
+
+공통 모듈 변경 없음 — B~E 에이전트가 미리 반영할 것은 없다.
+
+---
+
+## 6. 남은 것
+
+- KPA 밖의 organization 생성 경로(다른 서비스 · pharmacy-hub)는 이 WO 범위가 아니다. 미조사.
+- `organizations` 데이터 소유권 재설계 · 이중 entity 수렴은 여전히 별도 WO 대상이다.
+
+---
+
+문서 정합: 발견 0건 / SUPERSEDED 표기 0건 / 링크 수정 0건 / 별도 WO 제안 0건

--- a/docs/checks/CHECK-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1.md
+++ b/docs/checks/CHECK-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1.md
@@ -1,0 +1,142 @@
+# CHECK-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1
+
+- **WO**: WO-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1
+- **일자**: 2026-08-13
+- **범위**: KPA 회원 승인·재활성화 시 `users.businessInfo` → `organizations` 주소·약국 전화 write 정렬
+- **판정**: PASS
+- **선행**: `CHECK-O4O-KPA-BUSINESSINFO-KEY-READ-ALIGNMENT-V1` (공통 resolver) ·
+  `CHECK-O4O-CROSS-SERVICE-PROFILE-DATA-OWNERSHIP-AND-WRITE-PATH-INTEGRITY-AUDIT-V1` (D-3 · D-4)
+
+---
+
+## 1. 승인·재활성화별 기존 동기화 경로 (실측)
+
+| 전이 | organization 동기화 | 위치 | transaction 경계 |
+|---|---|---|---|
+| pending → active (`activity_type='pharmacy_owner'`) | **있음** — `ensureOrganization(code=kpa-pharm-{bizno})` + 연락처 write | `member.controller.ts` PATCH `/:id/status` | **commit 이후 후처리**, 자체 try/catch 로 비차단 |
+| pending → active (그 외 activity_type) | 없음 | — | — |
+| suspended → active (재활성화) | **없음** — `organizations` 에 어떤 write 도 없다 | `MembershipApprovalService.reactivateMembership` (organizations 참조 0건) | — |
+| rejected / suspended / withdrawn | 없음 | — | — |
+
+- KPA 승인 경로 외에 `kpa-pharm-*` organization 을 만드는 코드는 `PATCH /:id/info` 의
+  `activity_type → pharmacy_owner` 전환 블록뿐이다. 이 경로는 **연락처를 전혀 쓰지 않는다**
+  (조직·소유자·role 만 생성). 승인·재활성화가 아니므로 이번 범위에서 제외했다 — §8 참조.
+- `kpa_pharmacy_requests` 기반 승인 컨트롤러는 현재 저장소에 존재하지 않는다(은퇴).
+
+## 2. source key → destination 컬럼 (실측)
+
+| 축 | 기존 구현이 읽던 키 | destination | 문제 |
+|---|---|---|---|
+| 주소(기본) | `storeAddress.baseAddress` → `address` | `organizations.address` (기본+상세 결합 문자열) | ① `storeAddress` 우선이라 운영자가 고친 최신 `address` 가 밀림 ② `businessAddress` fallback 부재 |
+| 주소(상세) | `storeAddress.detailAddress` → `address2` | 위 문자열에 결합 | `businessAddressDetail` fallback 부재 |
+| 우편번호 | — | **없음** | 어디에도 기록되지 않음 |
+| 구조화 주소 | `storeAddress` 원본 통째 | `organizations.address_detail` (jsonb) | `storeAddress` 없으면 미기록 |
+| 약국 전화 | `metadata.pharmacy_phone` → **`phone`(대표 전화)** | `organizations.phone` | ① `pharmacyPhone`(공통 운영자 콘솔 키) 미인식 ② 대표 전화를 약국 전화로 승격 |
+
+`organizations.address_detail` 은 `jsonb`(`20260318200000-AddStructuredAddress`)이며
+shape 은 `{ zipCode, baseAddress, detailAddress }` (`store-organization.resolver.ts`) 이다.
+`users.businessInfo` 의 `json` 문제(직전 WO)와 달리 여기서는 `||` 병합이 유효하다.
+
+## 3. 신규 · 기존 organization 처리 방식
+
+- **신규 초기화**: `ensureOrganization` 직후 전 컬럼이 비어 있으므로 resolver 값으로 채운다.
+- **기존 보완**: 연락처 3축을 먼저 `SELECT` 해 **비어 있는 항목만** 채운다.
+  `address_detail` 은 통째 교체가 아니라 **키 단위**(`zipCode` / `baseAddress` / `detailAddress`)로 보완한다.
+- **덮어쓰기 없음**: 운영자가 매장 정보 화면에서 고친 값은 승인·재활성화만으로 되돌아가지 않는다.
+  JS plan 과 SQL `COALESCE(NULLIF(...))` · `$new || COALESCE(existing)` 양쪽에서 이중으로 보장한다.
+- **재활성화**: 기존과 동일하게 `organizations` 무변경 (테스트로 고정).
+
+## 4. 적용한 resolver 와 보존 규칙
+
+`apps/api-server/src/routes/kpa/shared/organizationContactSync.ts` (신규, 순수 함수)
+
+- 키 선택은 직전 WO 의 `resolveKpaBusinessContact` 를 **그대로 재사용**한다.
+  주소 `address` → `businessAddress` → `storeAddress.baseAddress`,
+  상세 `address2` → `businessAddressDetail` → `storeAddress.detailAddress`,
+  우편번호 `zipCode` → `storeAddress.zipCode`,
+  약국 전화 `metadata.pharmacy_phone` → `pharmacyPhone`.
+- 공백(`''` · 공백문자열)은 **값 부재**로 취급한다. 기존 컬럼이 공백이면 채우고,
+  원천 값이 공백이면 쓰지 않는다.
+- 채울 값이 없으면 `hasChanges=false` 로 **UPDATE 자체를 생략**한다 (임의 값·빈 문자열 write 없음).
+- 대표 전화(`businessInfo.phone`) fallback 은 **제거**했다. 약국 전화와 의미가 다르다.
+  결과적으로 대표 전화만 가진 회원은 `organizations.phone` 이 비어 있게 된다 — 의도된 변경이다.
+- `business_number` · `metadata`(taxInvoiceEmail / ceoName / contactName / managerPhone) write 는
+  기존 동작을 그대로 유지했다 (범위 밖).
+
+## 5. transaction · 후처리 경계와 실패 주입
+
+- 경계 변경 **없음**. 연락처 동기화는 승인 transaction commit **이후** 후처리이며 비차단이다.
+- 실패 주입: 연락처 `UPDATE organizations` 를 강제 실패시켜도
+  `txCommitted=1 / txRolledBack=0`, 500 응답 없음, 후속 `kpa_members.organization_id` 연결은 계속 진행.
+- 필수 승인 write(`service_memberships` · `users` · profile · `kpa_members`)의 단일 transaction·rollback 계약은
+  직전 WO 그대로이며 `member.controller.writeAtomicity.test.ts` · `MembershipApprovalService.txManagerInjection.test.ts`
+  16 suite 전량 통과로 회귀 없음을 확인했다.
+
+## 6. 테스트 · typecheck · read-only smoke
+
+| 항목 | 결과 |
+|---|---|
+| 신규 단위 테스트 `organizationContactSync.test.ts` | 13 passed (WO 검증 1~8) |
+| 신규 컨트롤러 테스트 `member.controller.orgContactSync.test.ts` | 8 passed (승인 초기화 · 보존 · 재활성화 무변경 · 실패 격리) |
+| 영향 범위 (`routes/kpa` · `services/approval` · `controllers/operator` · `auth/controllers`) | **16 suites / 209 tests 전량 PASS** |
+| `tsc --noEmit` (api-server, workspace 패키지 빌드 후) | **오류 0** |
+| read-only 프로덕션 실측 | 수행 (아래) |
+
+read-only 실측 (cloud-sql-proxy, SELECT/COUNT 만 · 개인정보 원문 미조회):
+
+| 측정 | 값 |
+|---|---|
+| `kpa-pharm-*` organization | 6건 |
+| ㄴ `address` 빈 값 | 2건 |
+| ㄴ `phone` 빈 값 | 3건 |
+| ㄴ `address_detail` NULL | 2건 |
+| ㄴ `address_detail.zipCode` 빈 값 | 2건 |
+| KPA 회원의 `businessInfo` 주소 키 — canonical `address` 보유 | 5건 |
+| ㄴ legacy `businessAddress` 보유 | 5건 / **legacy 단독 0건** |
+| ㄴ `storeAddress.baseAddress` 보유 | 5건 |
+| 약국 전화 — canonical `metadata.pharmacy_phone` | 2건 |
+| ㄴ legacy `pharmacyPhone` | 0건 / legacy 단독 0건 |
+| ㄴ 대표 `phone` 보유 | 0건 |
+| `kpa-pharm-*` 외 organization | 16건 (이번 변경 경로에서 접근하지 않음) |
+
+해석: 현재 모집단에는 **legacy 단독 회원이 없어** 이번 정렬로 값이 바뀌는 기존 row 는 없다.
+즉 이 변경은 **회귀 위험 없는 선제 정렬**이며, 실질 효과는 ① 우선순위 역전(운영자 수정값이 가입값에 밀림) 제거
+② 지금까지 기록되지 않던 우편번호 채움 ③ 대표 전화의 약국 전화 오염 차단이다.
+
+## 7. migration · backfill · 운영 API write · 배포
+
+| 항목 | 여부 |
+|---|---|
+| migration | 없음 |
+| backfill · 운영 데이터 일괄 변경 | 없음 |
+| 운영 DB write | **0건** (SELECT/COUNT 전용) |
+| 운영 API write smoke | 수행하지 않음 — read-only 실측으로 판정 가능했고, 불필요한 운영 데이터 변경을 피했다. 따라서 원복 대상 없음 · 순변화 0 |
+| 배포 | 하지 않음 (CI/CD 소관) |
+| 다른 서비스 organization 계약 | 변경 없음 (KPA 승인 경로 한정) |
+
+## 8. B~E 가 반영해야 할 공통 commit · 후속 제안
+
+- **공통 commit**: 이번 변경의 공통 기반은
+  `apps/api-server/src/routes/kpa/shared/organizationContactSync.ts` 1개 파일이며,
+  기존 공통 파일을 수정하지 않고 **신규 추가만** 했다. 따라서 B~E 작업과의 충돌면이 없어
+  별도 커밋 분리 없이 단일 커밋으로 처리했다. B~E 는 이 파일의
+  `planKpaOrganizationContactSync(businessInfo, existingOrgRow)` 계약을 그대로 소비하면 된다.
+- **후속 제안(별도 WO)**: `PATCH /kpa/members/:id/info` 의 `activity_type → pharmacy_owner`
+  전환 경로는 organization 을 새로 만들면서 주소·전화를 **전혀 채우지 않는다**.
+  같은 helper 로 정렬 가능하나 승인·재활성화 범위 밖이라 이번에는 손대지 않았다.
+- `organizations` 데이터 소유권 재설계 · 이중 entity 수렴은 예정대로 이번 범위 제외.
+
+## 9. 변경 파일
+
+**코드 4개(소스 2 · 테스트 2) · 문서 1개, 총 5개**
+
+
+| 파일 | 구분 |
+|---|---|
+| `apps/api-server/src/routes/kpa/shared/organizationContactSync.ts` | 소스 (신규) |
+| `apps/api-server/src/routes/kpa/controllers/member.controller.ts` | 소스 (수정) |
+| `apps/api-server/src/routes/kpa/shared/__tests__/organizationContactSync.test.ts` | 테스트 (신규) |
+| `apps/api-server/src/routes/kpa/controllers/__tests__/member.controller.orgContactSync.test.ts` | 테스트 (신규) |
+| `docs/checks/CHECK-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1.md` | 문서 (신규) |
+
+문서 정합: 발견 0건 / SUPERSEDED 표기 0건 / 링크 수정 0건 / 별도 WO 제안 1건 (§8 `/:id/info` 경로)


### PR DESCRIPTION
에이전트 A 공통 기반 작업. KPA 에서 `organizations` 를 만드는 **두 경로**가 서로 다른
주소·약국 전화 계약을 갖고 있던 문제를 하나의 공통 계약으로 정렬합니다.

| commit | WO | 경로 |
|---|---|---|
| `192086556` | WO-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1 | `PATCH /kpa/members/:id/status` (pending → active) |
| `1466d7d0e` | WO-O4O-KPA-ACTIVITY-TYPE-PHARMACY-OWNER-ORGANIZATION-CONTACT-ALIGNMENT-V1 | `PATCH /kpa/members/:id/info` (`activity_type` → `pharmacy_owner`) |

## 계약

신규 공통 순수 함수 `apps/api-server/src/routes/kpa/shared/organizationContactSync.ts`
(`planKpaOrganizationContactSync`) 가 "**써도 되는지**" 를 판단하고, 읽기 키 해석은
직전 WO 의 `resolveKpaBusinessContact` 를 그대로 재사용합니다.

- 신규 organization 은 resolver 결과로 초기화 (canonical `address`/`zipCode` → legacy `businessAddress` → 구조화 `storeAddress`)
- **기존 organization 의 유효한 값은 승인·전환만으로 덮어쓰지 않음** — JS plan + SQL `COALESCE(NULLIF(...))` 이중 방어
- `address_detail` 은 키 단위 병합(`$n::jsonb || COALESCE(address_detail,'{}')`) 으로 중첩 키 보존
- 공백은 값 부재로 취급, 채울 값이 없으면 UPDATE 자체를 생략
- **대표 전화(`businessInfo.phone`)를 약국 전화로 승격하지 않음** (기존 `metadata.pharmacy_phone || biz.phone` 결합 제거)
- 두 경로 모두 후처리 non-blocking 경계 유지 — 동기화 실패가 승인 transaction 이나 `store_owner` 부여 결과를 바꾸지 않음

## 검증

- `npx jest src/routes/kpa` → 8 suites / **101 tests PASS** (신규 36: shared 13 + 승인 경로 8 + 전환 경로 15)
- `npx tsc --noEmit` → 오류 0
- migration · backfill · 운영 DB write · 배포 없음. read-only 실측만 수행(개인정보 미조회 · 집계만).

## 범위 밖

`organizations` 데이터 소유권 재설계 · 이중 entity 수렴 · KPA 외 organization 생성 경로.

CHECK: `docs/checks/CHECK-O4O-KPA-APPROVAL-ORGANIZATION-CONTACT-WRITE-ALIGNMENT-V1.md` ·
`docs/checks/CHECK-O4O-KPA-ACTIVITY-TYPE-PHARMACY-OWNER-ORGANIZATION-CONTACT-ALIGNMENT-V1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
