### PR TITLE
feat(legal): 정책 문서 archive lifecycle 추가

### DIFF
--- a/apps/api-server/src/modules/service-legal/__tests__/service-policy-lifecycle.spec.ts
+++ b/apps/api-server/src/modules/service-legal/__tests__/service-policy-lifecycle.spec.ts
@@ -1,0 +1,30 @@
+import {
+  ServicePolicyLifecycleError,
+  resolveServicePolicyLifecycle,
+} from '../service-policy-lifecycle.js';
+
+describe('service policy document lifecycle', () => {
+  it('archives a draft', () => {
+    expect(resolveServicePolicyLifecycle('draft', 'archive')).toBe('archived');
+  });
+
+  it('restores an archived document as draft', () => {
+    expect(resolveServicePolicyLifecycle('archived', 'restore')).toBe('draft');
+  });
+
+  it.each([
+    ['published', 'archive', 'PUBLISHED_POLICY_CANNOT_BE_ARCHIVED'],
+    ['archived', 'archive', 'POLICY_ALREADY_ARCHIVED'],
+    ['draft', 'restore', 'POLICY_NOT_ARCHIVED'],
+    ['published', 'restore', 'POLICY_NOT_ARCHIVED'],
+  ] as const)('rejects %s -> %s', (status, action, code) => {
+    try {
+      resolveServicePolicyLifecycle(status, action);
+      throw new Error('expected lifecycle error');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ServicePolicyLifecycleError);
+      expect((error as ServicePolicyLifecycleError).code).toBe(code);
+      expect((error as ServicePolicyLifecycleError).httpStatus).toBe(409);
+    }
+  });
+});

--- a/apps/api-server/src/modules/service-legal/admin-service-legal.controller.ts
+++ b/apps/api-server/src/modules/service-legal/admin-service-legal.controller.ts
@@ -13,6 +13,7 @@
  *   POST /:serviceKey/policies                 — 등록 draft (admin)
  *   PUT  /:serviceKey/policies/:id             — 수정 (admin)
  *   PATCH /:serviceKey/policies/:id/publish    — 게시/해제 (admin)
+ *   PATCH /:serviceKey/policies/:id/lifecycle  — 보관/복원 (admin)
  *
  * 핵심:
  *   - 권한: requireServiceLegalScope — serviceKey 별 security-core config 적용
@@ -34,6 +35,11 @@ import {
   isSupportedPolicyDocumentType,
 } from './service-legal-scope.js';
 import logger from '../../utils/logger.js';
+import {
+  ServicePolicyLifecycleError,
+  resolveServicePolicyLifecycle,
+  type ServicePolicyLifecycleAction,
+} from './service-policy-lifecycle.js';
 
 /** camelCase 입력 → ServiceLegalProfile 컬럼 매핑 (mass-assignment 방지 화이트리스트). */
 const PROFILE_FIELD_MAP: Record<string, keyof ServiceLegalProfile> = {
@@ -244,6 +250,9 @@ export function createAdminServiceLegalController(dataSource: DataSource): Route
         if (!doc) {
           return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: '문서를 찾을 수 없습니다.' } });
         }
+        if (doc.status === 'archived') {
+          return res.status(409).json({ success: false, error: { code: 'POLICY_ARCHIVED', message: '보관된 문서는 복원 후 수정할 수 있습니다.' } });
+        }
         const before = toAdminPolicyDocument(doc);
         const { title, slug, content, version, effectiveDate, changeReason } = req.body;
         if (title !== undefined) {
@@ -297,6 +306,9 @@ export function createAdminServiceLegalController(dataSource: DataSource): Route
         if (!doc) {
           return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: '문서를 찾을 수 없습니다.' } });
         }
+        if (doc.status === 'archived') {
+          return res.status(409).json({ success: false, error: { code: 'POLICY_ARCHIVED', message: '보관된 문서는 복원 후 게시할 수 있습니다.' } });
+        }
         const before = toAdminPolicyDocument(doc);
 
         if (action === 'publish') {
@@ -335,6 +347,51 @@ export function createAdminServiceLegalController(dataSource: DataSource): Route
       } catch (error) {
         logger.error('[ServiceLegal Admin] publish policy error:', error);
         res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: '정책 문서 게시 처리 실패' } });
+      }
+    },
+  );
+
+  /**
+   * PATCH /:serviceKey/policies/:id/lifecycle — { action: 'archive' | 'restore' }
+   * 법적 문서 이력 보존을 위해 물리 DELETE를 제공하지 않는다.
+   */
+  router.patch(
+    '/:serviceKey/policies/:id/lifecycle',
+    authenticate,
+    requireServiceLegalScope('admin'),
+    async (req: Request, res: Response) => {
+      const serviceKey = req.params.serviceKey;
+      const userId = (req as any).user?.id ?? null;
+      const action = req.body?.action as ServicePolicyLifecycleAction | undefined;
+      if (!action || !['archive', 'restore'].includes(action)) {
+        return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: "action 은 archive 또는 restore 여야 합니다." } });
+      }
+
+      try {
+        const doc = await policyRepo.findOne({ where: { id: req.params.id, service_key: serviceKey } });
+        if (!doc) {
+          return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: '문서를 찾을 수 없습니다.' } });
+        }
+
+        const before = toAdminPolicyDocument(doc);
+        doc.status = resolveServicePolicyLifecycle(doc.status, action);
+        doc.updated_by = userId;
+        const saved = await policyRepo.save(doc);
+        const after = toAdminPolicyDocument(saved);
+        await audit(serviceKey, userId, `service_legal:policy_${action}`, {
+          entityType: 'service_policy_document',
+          entityId: saved.id,
+          documentType: saved.document_type,
+          before,
+          after,
+        });
+        return res.json({ success: true, data: after });
+      } catch (error) {
+        if (error instanceof ServicePolicyLifecycleError) {
+          return res.status(error.httpStatus).json({ success: false, error: { code: error.code, message: error.message } });
+        }
+        logger.error('[ServiceLegal Admin] lifecycle policy error:', error);
+        return res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: '정책 문서 보관 처리 실패' } });
       }
     },
   );

--- a/apps/api-server/src/modules/service-legal/entities/ServicePolicyDocument.entity.ts
+++ b/apps/api-server/src/modules/service-legal/entities/ServicePolicyDocument.entity.ts
@@ -37,7 +37,7 @@ export class ServicePolicyDocument {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  /** neture | glycopharm | kpa-society | k-cosmetics */
+  /** neture | glycopharm | kpa-society | k-cosmetics | pharmacy-hub */
   @Column({ type: 'varchar', length: 50 })
   service_key!: string;
 
@@ -64,7 +64,7 @@ export class ServicePolicyDocument {
   @Column({ type: 'int', default: 1 })
   version!: number;
 
-  /** draft | published */
+  /** draft | published | archived (물리 삭제 대신 이력 보존) */
   @Column({ type: 'varchar', length: 20, default: 'draft' })
   status!: string;
 

--- a/apps/api-server/src/modules/service-legal/service-policy-lifecycle.ts
+++ b/apps/api-server/src/modules/service-legal/service-policy-lifecycle.ts
@@ -1,0 +1,48 @@
+export type ServicePolicyStatus = 'draft' | 'published' | 'archived';
+export type ServicePolicyLifecycleAction = 'archive' | 'restore';
+
+export class ServicePolicyLifecycleError extends Error {
+  readonly code: string;
+  readonly httpStatus: number;
+
+  constructor(
+    code: string,
+    message: string,
+    httpStatus = 409,
+  ) {
+    super(message);
+    this.name = 'ServicePolicyLifecycleError';
+    this.code = code;
+    this.httpStatus = httpStatus;
+  }
+}
+
+/**
+ * 법적 문서는 감사 이력을 보존해야 하므로 물리 삭제 대신 archive/restore만 허용한다.
+ * 게시 중인 문서는 실수로 공개에서 사라지지 않도록 먼저 게시 해제해야 한다.
+ */
+export function resolveServicePolicyLifecycle(
+  currentStatus: string,
+  action: ServicePolicyLifecycleAction,
+): ServicePolicyStatus {
+  if (action === 'archive') {
+    if (currentStatus === 'published') {
+      throw new ServicePolicyLifecycleError(
+        'PUBLISHED_POLICY_CANNOT_BE_ARCHIVED',
+        '게시 중인 문서는 먼저 게시 해제해야 합니다.',
+      );
+    }
+    if (currentStatus === 'archived') {
+      throw new ServicePolicyLifecycleError('POLICY_ALREADY_ARCHIVED', '이미 보관된 문서입니다.');
+    }
+    if (currentStatus !== 'draft') {
+      throw new ServicePolicyLifecycleError('INVALID_POLICY_STATUS', '현재 상태에서는 문서를 보관할 수 없습니다.');
+    }
+    return 'archived';
+  }
+
+  if (currentStatus !== 'archived') {
+    throw new ServicePolicyLifecycleError('POLICY_NOT_ARCHIVED', '보관된 문서만 복원할 수 있습니다.');
+  }
+  return 'draft';
+}

--- a/packages/operator-core-ui/src/modules/service-legal/ServiceLegalSettingsPage.tsx
+++ b/packages/operator-core-ui/src/modules/service-legal/ServiceLegalSettingsPage.tsx
@@ -3,7 +3,7 @@
  *
  * WO-O4O-ADMIN-SERVICE-LEGAL-POLICY-SETTINGS-UI-V1
  *
- * 4 service 공통 컴포넌트. serviceKey + api 어댑터 주입으로 동작.
+ * 5 service 공통 컴포넌트. serviceKey + api 어댑터 주입으로 동작.
  * 3 탭: 법정정보 / 정책 문서 / 공개 상태 확인.
  *
  * 원칙:
@@ -65,7 +65,11 @@ const C = {
 
 /** 상태 배지 — O4O 표준 Tailwind 배지 패턴 */
 function policyStatusBadge(status: string) {
-  const cls = status === 'published' ? 'bg-emerald-50 text-emerald-700' : 'bg-amber-100 text-amber-800';
+  const cls = status === 'published'
+    ? 'bg-emerald-50 text-emerald-700'
+    : status === 'archived'
+      ? 'bg-slate-100 text-slate-600'
+      : 'bg-amber-100 text-amber-800';
   return <span className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold ${cls}`}>{status}</span>;
 }
 
@@ -242,6 +246,18 @@ export function ServiceLegalSettingsPage({ serviceKey, api, title, enabledTabs }
     }
   };
 
+  const handleLifecycle = async (d: ServicePolicyDocumentDto, action: 'archive' | 'restore') => {
+    setMessage(null);
+    try {
+      await api.changePolicyLifecycle(serviceKey, d.id, action);
+      setMessage({ type: 'success', text: action === 'archive' ? '문서가 보관되었습니다.' : '문서가 초안으로 복원되었습니다.' });
+      if (editing !== 'new' && editing?.id === d.id) setEditing(null);
+      await loadPolicies();
+    } catch (err: any) {
+      setMessage({ type: 'error', text: err?.message || '문서 보관 처리에 실패했습니다.' });
+    }
+  };
+
   const publishedByType = useMemo(() => {
     const m: Record<string, ServicePolicyDocumentDto> = {};
     for (const p of policies) if (p.status === 'published') m[p.documentType] = p;
@@ -271,10 +287,22 @@ export function ServiceLegalSettingsPage({ serviceKey, api, title, enabledTabs }
       render: (_v, d) => (
         <RowActionMenu
           actions={[
-            { key: 'edit', label: '편집', onClick: () => openEditDoc(d) },
-            d.status === 'published'
-              ? { key: 'unpublish', label: '게시해제', onClick: () => handlePublish(d, 'unpublish') }
-              : { key: 'publish', label: '게시', onClick: () => handlePublish(d, 'publish') },
+            ...(d.status === 'archived'
+              ? [{ key: 'restore', label: '초안으로 복원', onClick: () => handleLifecycle(d, 'restore') }]
+              : [
+                  { key: 'edit', label: '편집', onClick: () => openEditDoc(d) },
+                  d.status === 'published'
+                    ? { key: 'unpublish', label: '게시해제', onClick: () => handlePublish(d, 'unpublish') }
+                    : { key: 'publish', label: '게시', onClick: () => handlePublish(d, 'publish') },
+                  ...(d.status === 'draft'
+                    ? [{
+                        key: 'archive',
+                        label: '보관',
+                        onClick: () => handleLifecycle(d, 'archive'),
+                        confirm: { title: '정책 문서 보관', message: `“${d.title}” 문서를 보관하시겠습니까?` },
+                      }]
+                    : []),
+                ]),
           ]}
         />
       ),

--- a/packages/operator-core-ui/src/modules/service-legal/index.ts
+++ b/packages/operator-core-ui/src/modules/service-legal/index.ts
@@ -15,5 +15,6 @@ export type {
   ServicePolicyDocumentDto,
   ServicePolicyDocumentInput,
   PublishAction,
+  PolicyLifecycleAction,
   ServiceLegalSettingsPageProps,
 } from './types';

--- a/packages/operator-core-ui/src/modules/service-legal/types.ts
+++ b/packages/operator-core-ui/src/modules/service-legal/types.ts
@@ -3,7 +3,7 @@
  *
  * WO-O4O-ADMIN-SERVICE-LEGAL-POLICY-SETTINGS-UI-V1
  *
- * 4 service 공통 "법정정보·약관 설정" Admin UI 의 데이터/어댑터 타입.
+ * 5 service 공통 "법정정보·약관 설정" Admin UI 의 데이터/어댑터 타입.
  * 서버 endpoint 가 service-scoped + 인증이 필요하므로, 실제 HTTP 호출은 service 측
  * (각 web-* 의 authClient)에서 구현해 `ServiceLegalApi` 어댑터로 주입한다.
  *
@@ -11,6 +11,7 @@
  *   GET/PUT  /api/v1/admin/services/:serviceKey/legal-profile
  *   GET/POST/PUT /api/v1/admin/services/:serviceKey/policies[/:id]
  *   PATCH    /api/v1/admin/services/:serviceKey/policies/:id/publish
+ *   PATCH    /api/v1/admin/services/:serviceKey/policies/:id/lifecycle
  */
 
 /** 법정정보 (admin DTO — null 허용, placeholder 없음). */
@@ -69,7 +70,7 @@ export interface ServicePolicyDocumentDto {
   slug: string | null;
   content: string;
   version: number;
-  status: string; // draft | published
+  status: string; // draft | published | archived
   effectiveDate: string | null;
   publishedAt: string | null;
   publishedBy: string | null;
@@ -92,6 +93,7 @@ export interface ServicePolicyDocumentInput {
 }
 
 export type PublishAction = 'publish' | 'unpublish';
+export type PolicyLifecycleAction = 'archive' | 'restore';
 
 /**
  * service 측이 구현해 주입하는 어댑터.
@@ -105,6 +107,7 @@ export interface ServiceLegalApi {
   createPolicy(serviceKey: string, payload: ServicePolicyDocumentInput): Promise<ServicePolicyDocumentDto>;
   updatePolicy(serviceKey: string, id: string, payload: ServicePolicyDocumentInput): Promise<ServicePolicyDocumentDto>;
   publishPolicy(serviceKey: string, id: string, action: PublishAction): Promise<ServicePolicyDocumentDto>;
+  changePolicyLifecycle(serviceKey: string, id: string, action: PolicyLifecycleAction): Promise<ServicePolicyDocumentDto>;
 }
 
 /** UI 에 노출하는 정책 문서 유형 화이트리스트 (백엔드와 동일). */

--- a/services/web-glycopharm/src/pages/admin/ServiceLegalSettingsPage.tsx
+++ b/services/web-glycopharm/src/pages/admin/ServiceLegalSettingsPage.tsx
@@ -23,7 +23,7 @@ function toError(err: any): Error {
   if (status === 401) return new Error('로그인이 필요합니다.');
   if (status === 403) return new Error('이 서비스 설정을 수정할 권한이 없습니다.');
   if (status === 404) return new Error(typeof serverMsg === 'string' ? serverMsg : '데이터를 찾을 수 없습니다.');
-  if (status === 400 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
+  if (status === 400 || status === 409 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
   return new Error(typeof serverMsg === 'string' ? serverMsg : '서버 오류가 발생했습니다.');
 }
 
@@ -71,6 +71,14 @@ const legalApi: ServiceLegalApi = {
   async publishPolicy(serviceKey, id, action) {
     try {
       const res = await api.patch(`/admin/services/${serviceKey}/policies/${id}/publish`, { action });
+      return res.data?.data;
+    } catch (err) {
+      throw toError(err);
+    }
+  },
+  async changePolicyLifecycle(serviceKey, id, action) {
+    try {
+      const res = await api.patch(`/admin/services/${serviceKey}/policies/${id}/lifecycle`, { action });
       return res.data?.data;
     } catch (err) {
       throw toError(err);

--- a/services/web-k-cosmetics/src/pages/admin/ServiceLegalSettingsPage.tsx
+++ b/services/web-k-cosmetics/src/pages/admin/ServiceLegalSettingsPage.tsx
@@ -24,7 +24,7 @@ function toError(err: any): Error {
   if (status === 401) return new Error('로그인이 필요합니다.');
   if (status === 403) return new Error('이 서비스 설정을 수정할 권한이 없습니다.');
   if (status === 404) return new Error(typeof serverMsg === 'string' ? serverMsg : '데이터를 찾을 수 없습니다.');
-  if (status === 400 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
+  if (status === 400 || status === 409 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
   return new Error(typeof serverMsg === 'string' ? serverMsg : '서버 오류가 발생했습니다.');
 }
 
@@ -72,6 +72,14 @@ const legalApi: ServiceLegalApi = {
   async publishPolicy(serviceKey, id, action) {
     try {
       const res = await api.patch(`/admin/services/${serviceKey}/policies/${id}/publish`, { action });
+      return res.data?.data;
+    } catch (err) {
+      throw toError(err);
+    }
+  },
+  async changePolicyLifecycle(serviceKey, id, action) {
+    try {
+      const res = await api.patch(`/admin/services/${serviceKey}/policies/${id}/lifecycle`, { action });
       return res.data?.data;
     } catch (err) {
       throw toError(err);

--- a/services/web-kpa-society/src/pages/admin/ServiceLegalSettingsPage.tsx
+++ b/services/web-kpa-society/src/pages/admin/ServiceLegalSettingsPage.tsx
@@ -30,7 +30,7 @@ function toError(err: any): Error {
   if (status === 401) return new Error('로그인이 필요합니다.');
   if (status === 403) return new Error('이 서비스 설정을 수정할 권한이 없습니다.');
   if (status === 404) return new Error(typeof serverMsg === 'string' ? serverMsg : '데이터를 찾을 수 없습니다.');
-  if (status === 400 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
+  if (status === 400 || status === 409 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
   return new Error(typeof serverMsg === 'string' ? serverMsg : '서버 오류가 발생했습니다.');
 }
 
@@ -69,6 +69,12 @@ const legalApi: ServiceLegalApi = {
   async publishPolicy(serviceKey, id, action) {
     try {
       const res = await coreApiClient.patch<{ data: any }>(`/admin/services/${serviceKey}/policies/${id}/publish`, { action });
+      return (res as any)?.data;
+    } catch (err) { throw toError(err); }
+  },
+  async changePolicyLifecycle(serviceKey, id, action) {
+    try {
+      const res = await coreApiClient.patch<{ data: any }>(`/admin/services/${serviceKey}/policies/${id}/lifecycle`, { action });
       return (res as any)?.data;
     } catch (err) { throw toError(err); }
   },

--- a/services/web-neture/src/pages/admin/ServiceLegalSettingsPage.tsx
+++ b/services/web-neture/src/pages/admin/ServiceLegalSettingsPage.tsx
@@ -23,7 +23,7 @@ function toError(err: any): Error {
   if (status === 401) return new Error('로그인이 필요합니다.');
   if (status === 403) return new Error('이 서비스 설정을 수정할 권한이 없습니다.');
   if (status === 404) return new Error(typeof serverMsg === 'string' ? serverMsg : '데이터를 찾을 수 없습니다.');
-  if (status === 400 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
+  if (status === 400 || status === 409 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
   return new Error(typeof serverMsg === 'string' ? serverMsg : '서버 오류가 발생했습니다.');
 }
 
@@ -71,6 +71,14 @@ const legalApi: ServiceLegalApi = {
   async publishPolicy(serviceKey, id, action) {
     try {
       const res = await api.patch(`/admin/services/${serviceKey}/policies/${id}/publish`, { action });
+      return res.data?.data;
+    } catch (err) {
+      throw toError(err);
+    }
+  },
+  async changePolicyLifecycle(serviceKey, id, action) {
+    try {
+      const res = await api.patch(`/admin/services/${serviceKey}/policies/${id}/lifecycle`, { action });
       return res.data?.data;
     } catch (err) {
       throw toError(err);

--- a/services/web-pharmacy-hub/src/pages/operator/ServiceLegalSettingsPage.tsx
+++ b/services/web-pharmacy-hub/src/pages/operator/ServiceLegalSettingsPage.tsx
@@ -33,7 +33,7 @@ function toError(err: any): Error {
   if (status === 401) return new Error('로그인이 필요합니다.');
   if (status === 403) return new Error('이 서비스 설정을 수정할 권한이 없습니다. (저장은 서비스 관리자 권한이 필요합니다)');
   if (status === 404) return new Error(typeof serverMsg === 'string' ? serverMsg : '데이터를 찾을 수 없습니다.');
-  if (status === 400 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
+  if (status === 400 || status === 409 || status === 422) return new Error(typeof serverMsg === 'string' ? serverMsg : '입력값을 확인해 주세요.');
   return new Error(typeof serverMsg === 'string' ? serverMsg : '서버 오류가 발생했습니다.');
 }
 
@@ -82,6 +82,14 @@ const legalApi: ServiceLegalApi = {
   async publishPolicy(serviceKey, id, action) {
     try {
       const res = await api.patch(`/admin/services/${serviceKey}/policies/${id}/publish`, { action });
+      return res.data?.data;
+    } catch (err) {
+      throw toError(err);
+    }
+  },
+  async changePolicyLifecycle(serviceKey, id, action) {
+    try {
+      const res = await api.patch(`/admin/services/${serviceKey}/policies/${id}/lifecycle`, { action });
       return res.data?.data;
     } catch (err) {
       throw toError(err);


### PR DESCRIPTION
## Summary
- 정책 문서에 복구 가능한 `archive` / `restore` lifecycle을 추가합니다.
- published 문서의 직접 archive와 archived 문서의 수정·발행을 차단합니다.
- 공통 Operator UI 및 공식 5서비스 adapter를 동일 계약으로 정렬합니다.

## Scope
- 물리 DELETE 없음
- DB schema/migration 변경 없음
- 법적 문구 생성·수정 없음
- Neture/GlycoPharm footer 및 `/terms`, `/privacy` route는 이미 정상이라 무변경

## Validation
- lifecycle 순수 함수 smoke PASS
- `git diff --check` PASS
- 로컬 의존성 설치는 실행 환경 네트워크/패키지 캐시 제약으로 불가하여 PR CI로 전체 type-check/build를 검증합니다.

WO: `WO-O4O-SERVICE-LEGAL-DOCUMENT-LIFECYCLE-AND-RESIDUAL-CLEANUP-V1`