### PR TITLE
feat(glycopharm): 승인 공급 카탈로그를 canonical B2B 장바구니 producer 로 연결한다

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -185,6 +185,16 @@ jobs:
     - name: Run tests (appearance-system Jest)
       run: cd packages/appearance-system && NODE_OPTIONS=--experimental-vm-modules npx jest --config jest.config.cjs
 
+    # WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1
+    # 카탈로그 행 → canonical store_cart_items payload 계약(offer id · supplier 축 ·
+    # 표시용 가격 · organizationId 미전송)을 CI 에서 고정한다. blocking.
+    # GlycoPharm 에는 테스트 실행 경로가 아예 없었다 — 이 축은 잘못되면 legacy 상품 id 나
+    # 표시용 가격이 조용히 주문 경로로 새어 들어간다.
+    # (store-ui-core 의 opt-in 장바구니 producer 계약은 위 store-ui-core step 에서 실행된다.)
+    # DB · secret 불필요. 루트에 설치된 vitest/jsdom 을 그대로 쓴다.
+    - name: Run tests (web-glycopharm Vitest)
+      run: npx vitest run --config services/web-glycopharm/vitest.config.mjs
+
   # 2. Build all applications
   build:
     name: Build Applications

--- a/apps/api-server/src/services/cart/__tests__/offer-exposure-strategy.test.ts
+++ b/apps/api-server/src/services/cart/__tests__/offer-exposure-strategy.test.ts
@@ -66,8 +66,18 @@ describe('approval strategy (§30)', () => {
 
   it('승인 행 조건을 SQL 에서 강제한다 — service_keys opt-in 으로 우회되지 않는다', () => {
     expect(s.offerWhereSql).toContain('offer_service_approvals');
-    expect(s.offerWhereSql).toContain("approval_status = 'APPROVED'");
+    expect(s.offerWhereSql).toContain("osa.approval_status = 'approved'");
     expect(s.offerWhereSql).not.toContain('service_keys');
+  });
+
+  // WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1 (§19)
+  //   `offer_service_approvals.approval_status` 는 **소문자** 도메인이다. 대문자
+  //   'APPROVED' 로 비교하면 EXISTS 가 항상 거짓이 되어 승인축 서비스 전체
+  //   (glycopharm / kpa-society / k-cosmetics)의 B2B confirm 이 조용히 0건이 된다.
+  //   게이트 완화가 아니라 **같은 축을 같은 표기로 비교**하는 정합 회귀 테스트다.
+  it("승인 junction 비교는 카탈로그 SSOT 와 같은 소문자 'approved' 를 쓴다", () => {
+    expect(s.offerWhereSql).not.toContain("osa.approval_status = 'APPROVED'");
+    expect(s.offerWhereSql).toMatch(/osa\.approval_status\s*=\s*'approved'/);
   });
 
   it('승인된 노출은 통과한다', () => {

--- a/apps/api-server/src/services/cart/__tests__/store-b2b-cart-checkout.test.ts
+++ b/apps/api-server/src/services/cart/__tests__/store-b2b-cart-checkout.test.ts
@@ -100,7 +100,11 @@ describe('승인 게이트 (§18 · §19)', () => {
     await service.confirm(scope);
 
     expect(queries[0].sql).toContain('offer_service_approvals');
-    expect(queries[0].sql).toContain("approval_status = 'APPROVED'");
+    // WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1 (§19):
+    //   junction 승인 상태는 소문자 도메인('approved')이다. 대문자는
+    //   supplier_product_offers 축이며, 섞으면 승인 offer 가 0건으로 매칭된다.
+    expect(queries[0].sql).toContain("osa.approval_status = 'approved'");
+    expect(queries[0].sql).not.toContain("osa.approval_status = 'APPROVED'");
     // PharmacyHub 식 opt-in 축은 이 서비스의 노출 근거가 아니다
     expect(queries[0].sql).not.toContain('service_keys');
     expect(queries[0].params[1]).toBe('glycopharm');

--- a/apps/api-server/src/services/cart/offer-exposure-strategy.ts
+++ b/apps/api-server/src/services/cart/offer-exposure-strategy.ts
@@ -103,6 +103,14 @@ export interface OfferExposureStrategy {
  * `offer_service_approvals` 의 승인 행이 노출 권위다. 프로덕션에 승인 행이 몇 건인지와
  * 무관하게 게이트를 완화하지 않는다 — 0건이면 "공급 승인/온보딩이 없다"는 사실이지
  * 게이트를 낮출 근거가 아니다.
+ *
+ * 표기 축 (WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1 §19):
+ *   `offer_service_approvals.approval_status` 는 **소문자** 도메인이다
+ *   (entity default 'pending', backfill migration 'approved', 카탈로그 SSOT
+ *   `buildServiceApprovalGateSql` 도 'approved').
+ *   대문자 'APPROVED' 는 `supplier_product_offers.approval_status` 의 축이다.
+ *   두 축을 섞으면 EXISTS 가 항상 거짓이 되어 승인축 서비스 전체의 B2B confirm 이
+ *   조용히 0건이 된다 — 완화가 아니라 정합의 문제다.
  */
 const approvalStrategy: OfferExposureStrategy = {
   key: 'approval',
@@ -112,7 +120,8 @@ const approvalStrategy: OfferExposureStrategy = {
                 SELECT 1 FROM offer_service_approvals osa
                  WHERE osa.offer_id = spo.id
                    AND osa.service_key = $2
-                   AND osa.approval_status = 'APPROVED'
+                   -- 소문자 도메인이다 (윗 주석 참조). 대문자로 비교하지 않는다.
+                   AND osa.approval_status = 'approved'
               )`,
   gate(offer, ctx) {
     if (offer.master_status !== 'ACTIVE') {

--- a/docs/baseline/O4O-B2B-SUPPLIER-TO-STORE-ORDER-CONTRACT-V1.md
+++ b/docs/baseline/O4O-B2B-SUPPLIER-TO-STORE-ORDER-CONTRACT-V1.md
@@ -306,6 +306,9 @@ KPA · GlycoPharm · K-Cosmetics · PharmacyHub 에 공급자 주문 화면을 �
 | DF-4 | 매장 buyer 주문 조회 컨트롤러가 KPA / GlycoPharm / K-Cosmetics 3벌로 중복 | `B2B_COMMONIZABLE` 로 분류. 공통화는 3서비스 동시 회귀가 필요해 별도 WO |
 | ↳ **DF-4 종결** | 동일 WO | 3벌 조회 SQL 을 `services/checkout/buyer-order-read.service.ts` 하나로 모았다. controller 3개는 thin wrapper |
 | DF-5 | GlycoPharm 에 **`sourceType: 'b2b'` 를 만드는 frontend 생산자가 없다.** 서버(`checkout-confirm-b2b`)와 공통 client(`useStoreCart`)는 준비됐지만 승인 공급 상품을 장바구니에 담는 화면이 없다. `/store/commerce/products` 는 "공급 상품 **신청**"(ProductApproval PENDING) 이며 신청 ≠ 주문 | 담기 버튼을 붙이는 것은 그 화면의 **의미를 바꾸는 제품/UX 결정**이다 (DF-2 와 같은 이유). 임의 배선 금지 |
+| ↳ **DF-5 종결** | `WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1` | 새 주문 UI 를 만들지 않고, `/store/commerce/products` 카탈로그를 **opt-in** cart producer 로 연결했다(§13-6). "신청"(ProductApproval) 액션은 그대로 남고 "담기"가 별개 액션으로 추가된다 — 담기 ≠ 신청 ≠ 주문 |
+| DF-7 | GlycoPharm 다중 매장(조직) 사용자를 위한 **조직 선택 UI 가 없다.** 서버는 `AMBIGUOUS_STORE_ORGANIZATION` 으로 fail closed 하고 화면은 그 사유를 그대로 보여준다 | 임의로 첫 조직을 고르지 않는 것이 계약(§13-3)이다. 선택 UI 는 조직 목록 조회 표면이 새로 필요하므로 별도 WO |
+| DF-8 | 승인축 `gate` 의 PRIVATE 판정은 `allowed_seller_ids` 를 **buyerId(사용자)** 와 비교하는데, 카탈로그 노출 판정은 **organizationId(매장)** 와 비교한다 — 카탈로그에 보이는 PRIVATE offer 가 confirm 에서 거부될 수 있다 | 공급 승인 정책의 축을 바꾸는 변경이고 glycopharm · kpa-society · k-cosmetics 3서비스에 동시 영향이다. 완화가 아니라 축 정렬이므로 별도 WO |
 | DF-6 | `neture` 노출 strategy 는 `spo.deleted_at IS NULL` 을 걸지 않는다 — soft-delete 된 offer 가 Neture confirm 에서 여전히 보인다 | 현행 main 과 **정확히 동일한 동작**이다. confirm 공통화 WO 에서 Neture 노출 범위를 바꾸면 §22 회귀 위험. 별도 WO 로 축소 |
 
 **DEFERRED 는 "모른다" 가 아니다.** 판정은 끝났고 실행만 미룬 것이다. `UNKNOWN = 0`.
@@ -408,7 +411,7 @@ confirm 의 **공통부는 서비스 무관(service-agnostic)** 이다.
 
 | strategy | 서비스 | 노출 근거 (SQL) | gate |
 |---|---|---|---|
-| `approval` | glycopharm · kpa-society · k-cosmetics | `EXISTS offer_service_approvals(offer_id, service_key, APPROVED)` | `MASTER_INACTIVE` · `DISTRIBUTION_DENIED` |
+| `approval` | glycopharm · kpa-society · k-cosmetics | `EXISTS offer_service_approvals(offer_id, service_key, approval_status = 'approved')` | `MASTER_INACTIVE` · `DISTRIBUTION_DENIED` |
 | `optin` | pharmacy-hub | `$key = ANY(spo.service_keys)` | `DISTRIBUTION_DENIED` · `MASTER_INACTIVE` |
 | `neture` | neture | 없음 (junction 미사용) | `PRODUCT_NOT_APPROVED` · `DISTRIBUTION_DENIED` |
 
@@ -420,6 +423,14 @@ confirm 의 **공통부는 서비스 무관(service-agnostic)** 이다.
 
 **불변식 C5.** strategy 에 등록되지 않은 serviceKey 는 B2B confirm 대상이 아니다
 (`UNSUPPORTED_CART_SERVICE`).
+
+**불변식 C6** (WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1).
+`offer_service_approvals.approval_status` 는 **소문자** 도메인이다(`pending` / `approved` / …).
+대문자 `'APPROVED'` 는 `supplier_product_offers.approval_status` 의 축이며 서로 다른 축이다.
+confirm 의 노출 SQL 은 카탈로그 SSOT(`buildServiceApprovalGateSql`)와 **같은 표기**로 비교해야 한다 —
+섞이면 `EXISTS` 가 항상 거짓이 되어 승인축 서비스 전체의 B2B confirm 이 조용히 0건이 된다.
+이는 게이트 완화가 아니라 정합 문제이며, 회귀 테스트로 고정한다
+(`offer-exposure-strategy.test.ts` · `store-b2b-cart-checkout.test.ts`).
 
 ### 13-3. buyer 매장 조직 — **서버가 권위다**
 
@@ -474,7 +485,33 @@ confirm 의 **공통부는 서비스 무관(service-agnostic)** 이다.
 `metadata.serviceKey` → `neture_orders.service_key` 이고 `source` 는 bridge 진입 자격 판정용이다.
 **등록하지 않으면 주문은 생성·결제되고도 공급자에게 영원히 보이지 않는다.**
 
-### 13-6. 금지
+### 13-6. cart producer — 승인 카탈로그가 유일한 B2B 담기 출처다
+
+WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1.
+
+`store_cart_items(sourceType='b2b')` 를 만드는 화면은 **승인된 공급 카탈로그**
+(`supplier_product_offers` 기반 catalog SSOT) 뿐이다. 카탈로그 행의 `id` 가 곧
+`supplier_product_offers.id` 이며, 이 값이 `supplierProductOfferId` 로 그대로 간다.
+
+| 축 | 권위 | 클라이언트가 보내는 값 |
+|---|---|---|
+| offer | `supplier_product_offers.id` (= 카탈로그 행 id) | 그대로 전달 |
+| supplier | `neture_suppliers.id` | 힌트(`requireCartSupplierId=false`) |
+| 가격 | 서버 `offer_service_prices[serviceKey]` → `price_general` | 표시용 snapshot 만 |
+| 매장 조직 | 서버 `resolveBuyerOrganization` | **보내지 않는다** |
+
+금지:
+
+- legacy 서비스 자체 상품(예: `glycopharm_products`)을 B2B 주문 source 로 쓰는 것
+- 표시명(`supplierName`) · manufacturer 문자열을 공급자 식별자로 쓰는 것
+- sku · barcode heuristic 으로 offer 를 매칭하는 것
+- frontend 가 승인·유통·조직 자격을 선판단해 담기를 막거나 허용하는 것
+  (자격 판정은 confirm 시 서버가 한다 — 담기 ≠ 주문)
+
+공통 컴포넌트(`SupplyCatalogHub`)에서 담기 UI 는 **opt-in** 이다. `cart` prop 을 주지 않은
+서비스는 렌더 트리·액션·문구가 종전과 동일해야 한다(신청 ≠ 주문 경계 유지).
+
+### 13-7. 금지
 
 1. wrapper 가 offer 재조회 SQL · 단가 확정 · order 생성을 직접 하는 것
 2. `req.body.organizationId` 를 검증 없이 소유 축으로 쓰는 것

--- a/docs/checks/WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1-CHECK.md
+++ b/docs/checks/WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1-CHECK.md
@@ -199,7 +199,32 @@ ActionBar 액션도 조건부다. KPA-Society · K-Cosmetics 는 prop 을 주지
 
 - 작업 격리 worktree: `C:/tmp/o4o-b2b-buyer-order-read` (branch `work/b2b-confirm-service-agnostic-v1`, base `origin/main` `063e811a5`)
 - Safe Commit 계약 준수: 명시 경로 `git add` → `node scripts/git/check-staged-scope.mjs` → 경로 스코프 commit. `git add .` 미사용, 타 세션 파일 미조작.
-- commit / push / CI 결과는 아래에 추가한다.
+- commit / push / CI 결과 (§48):
+
+| 항목 | 실측 |
+|---|---|
+| 커밋 1 | `1690f1377` feat(glycopharm): 승인 공급 카탈로그를 canonical B2B 장바구니 producer 로 연결한다 (14 파일) |
+| 커밋 2 | `c1ee1941a` fix(glycopharm): cart payload 테스트의 Record 캐스팅을 tsc 통과하도록 고친다 (1 파일) |
+| 최종 base | `origin/main` `b5bab1f4d` |
+| remote head | `c1ee1941a` — local HEAD 와 일치 확인 |
+| PR | [#185](https://github.com/Renagang21/o4o-platform/pull/185), `mergeable: MERGEABLE` |
+| CI Pipeline | **success** |
+| Guard Policy Check | success |
+| CodeQL Security Analysis | success |
+| PR Size Labeler | success |
+
+**rebase 기록.** 작업 중 `origin/main` 이 3회 앞서 나갔다(`4be07ba57` → `d16c38caf` → `b5bab1f4d`).
+매번 `.github/workflows/ci-pipeline.yml` 에서 충돌했으나 세 경우 모두 **서로 겹치지 않는 additive
+CI step** 이었으므로 양쪽을 모두 유지해 해소했다. 어느 쪽 step 도 삭제하지 않았다:
+package-level Vitest 5 step(`4be07ba57`) · package-level Jest 3 step(`18033e1cf`) ·
+본 WO 의 web-glycopharm Vitest 1 step 이 최종 파일에 모두 존재한다(실측 4·1건).
+remote 정렬에는 `--force-with-lease` 만 사용했다(`--force` 미사용) — 사용자 승인 후 수행.
+
+**CI 가 잡은 결함 1건.** 로컬 vitest 는 타입 검사를 하지 않으므로 `AddCartItemInput` 에
+index signature 가 없어 `as Record<string, unknown>` 직접 캐스팅이 TS2352 로 막히는 것을
+로컬에서 놓쳤고, CI `type-check:frontend` 의 `services/web-glycopharm` 단계에서 처음 드러났다.
+`as unknown as Record<string, unknown>` 으로 고쳤다(커밋 2). §14 검사 의도는 불변 —
+런타임 키 존재 여부만 본다.
 
 ## 7. DEFERRED
 

--- a/docs/checks/WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1-CHECK.md
+++ b/docs/checks/WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1-CHECK.md
@@ -1,0 +1,210 @@
+# WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1 — CHECK
+
+> 목표 흐름
+>
+> ```
+> /store/commerce/products → 승인된 supplier_product_offers → canonical store_cart_items
+>   → service-agnostic B2B checkout confirm → checkout_orders → buyer order ledger
+> ```
+>
+> **새 주문 UI 를 만드는 작업이 아니다.** 이미 존재하는 canonical 공급 카탈로그를,
+> 이미 완성된 B2B cart/confirm/order 축의 **실제 producer** 로 연결하는 작업이다.
+> 이 WO 로 baseline §10 의 **DF-5 가 종결**된다. DF-3(KPA 관심상품)은 계속 DEFERRED.
+
+---
+
+## 1. 전수조사 (§7) — `UNKNOWN = 0` · `UNJUDGED = 0`
+
+### 1-1. 카탈로그 축 (producer 의 출처)
+
+| 대상 | 실측 | 판정 |
+|---|---|---|
+| 화면 | `services/web-glycopharm/src/pages/store-management/PharmacyB2BProducts.tsx` (43줄 thin wrapper) | canonical |
+| 공통 컴포넌트 | `packages/store-ui-core/.../SupplyCatalogHub.tsx` (GlycoPharm · K-Cosmetics · KPA 공유) | 공유 — 변경 시 opt-in 필수 |
+| client | `services/web-glycopharm/src/api/pharmacyProducts.ts` → `createSupplyCatalogApi('/glycopharm')`, `service_key: 'glycopharm'` | canonical |
+| 서버 | `apps/api-server/src/routes/o4o-store/controllers/pharmacy-products.controller.ts` `GET /catalog` | canonical |
+| 행 id 축 | `SELECT spo.id AS "id"` — **카탈로그 행 id = SupplierProductOffer id** | producer 가 그대로 쓸 수 있다 |
+| supplier 축 | `s.id AS "supplierId"` (= `neture_suppliers.id` = `spo.supplier_id`) | confirm 의 grouping 축과 동일 |
+| 노출 게이트 | `buildServiceApprovalGateSql` — `PUBLIC` OR `EXISTS offer_service_approvals(service_key, approval_status='approved')` + `buildPrivateSellerScopeSql(allowed_seller_ids ∋ organizationId)` + `spo.is_active` + `s.status='ACTIVE'` | 서버 판정 |
+| 조직 축 | `requireAuth` + `requirePharmacyOwner`, `organizationId` **서버 확정** | 클라이언트 미참여 |
+
+### 1-2. 주문 축 (이미 완성돼 있던 것)
+
+| 대상 | 실측 | 판정 |
+|---|---|---|
+| cart 저장 | `store_cart_items` / `services/cart/store-cart.service.ts` | canonical |
+| cart route | `/api/v1/store/cart/:serviceKey/*`, `resolveScope` = 인증 + `hasActiveServiceMembership` | §34 우회 불가 |
+| cart client | `packages/store-ui-core/.../createStoreCartApi.ts` `addItem(serviceKey, input)` | 이미 존재 |
+| 축 라우팅 | `useStoreCart.confirmCheckout` — `b2b`/`regular` 항목이 있으면 `checkoutConfirmB2B` | **§18 이미 충족, 무변경** |
+| 장바구니 화면 | `services/web-glycopharm/src/pages/store-cart/StoreCartPage.tsx` → `/store-hub/cart` | 이미 존재 |
+| confirm Core | `services/cart/b2b-checkout-confirm.core.ts` (service-agnostic) | canonical |
+| GlycoPharm adapter | `store-b2b-cart-checkout.service.ts` — `organizationPolicy: 'required'`, `requireCartSupplierId: false`, `enforceCartSupplierMatch: false` | canonical |
+| 노출 정책 | `offer-exposure-strategy.ts` `approvalStrategy` (glycopharm · kpa-society · k-cosmetics) | 유일한 서비스 분기점 |
+
+### 1-3. 계약 실측 (§13 · §22 · §23 · §24 · §25)
+
+| 항목 | 실측 근거 (Core) | 판정 |
+|---|---|---|
+| 가격 권위 | `buildOfferQuery` 의 `offer_service_prices(service_key=$2)` → 없으면 `price_general` fallback | cart snapshot 미신뢰 |
+| 혼합 sourceType | `B2B_ORDERABLE_SOURCE_TYPES = {b2b, regular}` 외는 `failedItems` | event_offer 축 격리 |
+| 공급자 grouping | 서버 `offer.supplier_id` 기준. 실패 항목이 속한 그룹은 **전체 무효화**(poisoned) | 금액 일관성 |
+| 수량 | 정수 · `1..1000` 아니면 `INVALID_QUANTITY` | 서버 판정 |
+| 실패 처리 | fail closed. cart 삭제는 성공 그룹만, `id + buyerId + serviceKey` 스코프 | 강행 주문 없음 |
+| 조직 | `resolveBuyerOrganization` — `none`→403 / `ambiguous`→400 / `forbidden`→403 | 임의 첫 조직 선택 없음 |
+
+### 1-4. 은퇴 축 보존 (§30 · §32)
+
+| 대상 | 실측 | 판정 |
+|---|---|---|
+| `/store/b2b-order` | `App.tsx:1089` → `B2BOrderRetiredPage` (은퇴 안내) | 무변경 |
+| GlycoPharm consumer checkout | `routes/glycopharm/controllers/checkout.controller.ts:125` → `410 STORE_SALE_PAYMENT_DEPRECATED` | 무변경 |
+| legacy event-offer 외부 route | `event-offer.controller.ts:97` → `410` | 무변경 |
+| `glycopharm_products` | 주문 source 로 사용하지 않음 (producer payload 는 offer id 만 사용) | 계약 유지 |
+
+---
+
+## 2. 발견된 결함 (§19)
+
+### 2-1. BLOCKING — 승인 junction 표기 축 불일치
+
+`apps/api-server/src/services/cart/offer-exposure-strategy.ts` 의 `approvalStrategy.offerWhereSql` 이
+`osa.approval_status = 'APPROVED'` (대문자)로 비교하고 있었다.
+
+| 축 | 표기 | 근거 |
+|---|---|---|
+| `offer_service_approvals.approval_status` | **소문자** | entity default `'pending'`, backfill migration `20260328000100` 이 `'approved'` 삽입, 카탈로그 SSOT `buildServiceApprovalGateSql` 도 `'approved'` |
+| `supplier_product_offers.approval_status` | 대문자 | `neture.routes.ts` 등 기존 코드가 `'APPROVED'` |
+
+repo 전수 grep 결과 `offer_service_approvals` 를 대문자로 비교하는 곳은 이 한 군데뿐이었다.
+영향: 승인축 3서비스(glycopharm · kpa-society · k-cosmetics)의 B2B confirm 에서 `EXISTS` 가
+항상 거짓 → **모든 offer 가 `OFFER_NOT_FOUND` 로 실패**. 즉 이 WO 의 목표 흐름이 성립하지 않는다.
+
+판정: **게이트 완화가 아니라 축 정합 수정**이다(§9 위반 아님). 승인 행이 없는 offer 는 여전히 주문 불가다.
+회귀 테스트 2건으로 고정했다.
+
+> 이 결함은 선행 WO(`...B2B-CHECKOUT-CONFIRM-SERVICE-AGNOSTIC-ADOPTION-V1`)에서 유입된 것이다.
+> 과거 CHECK 의 역사적 기술은 소급 수정하지 않고, 본 문서에 현재 사실로 기록한다.
+
+### 2-2. DEFERRED — PRIVATE 판정 축 불일치 (baseline DF-8)
+
+`approvalStrategy.gate` 는 PRIVATE offer 의 `allowed_seller_ids` 를 **`ctx.buyerId`(사용자)** 와 비교하는데,
+카탈로그 노출은 **organizationId(매장)** 와 비교한다. 카탈로그에 보이는 PRIVATE offer 가 confirm 에서
+`DISTRIBUTION_DENIED` 로 거부될 수 있다.
+
+미루는 이유: 공급 승인 정책의 축을 바꾸는 변경이고 3서비스 동시 영향이다(§5 OUT_OF_SCOPE — 승인 정책 변경).
+**완화 방향이 아니므로 안전 측 실패**다. baseline §10 DF-8 로 등재했다.
+
+### 2-3. DEFERRED — 다중 매장 조직 선택 UI (baseline DF-7)
+
+`useStoreCart` 는 `organizationId` 를 보내지 않는다. 조직이 2개 이상인 사용자는 서버가
+`AMBIGUOUS_STORE_ORGANIZATION`(400) 으로 fail closed 하고, 화면은 그 사유를 그대로 보여준다.
+**임의로 첫 조직을 고르지 않는다(§14 준수).** 선택 UI 는 조직 목록 조회 표면이 새로 필요하므로 별도 WO.
+
+---
+
+## 3. 변경 내용
+
+| # | 파일 | 내용 |
+|---|---|---|
+| 1 | `apps/api-server/src/services/cart/offer-exposure-strategy.ts` | 승인 junction 비교를 `'approved'` (소문자)로 정정 + 표기 축 주석 |
+| 2 | `.../cart/__tests__/offer-exposure-strategy.test.ts` | 소문자 표기 회귀 테스트 추가, 기존 단정 갱신 |
+| 3 | `.../cart/__tests__/store-b2b-cart-checkout.test.ts` | 승인 게이트 SQL 단정을 소문자 축으로 갱신 |
+| 4 | `packages/store-ui-core/.../SupplyCatalogHub.tsx` | **opt-in** `cart` prop (`SupplyCatalogCartProducer`) — 행 단위 담기 · 선택 일괄 담기 · 결과/실패 안내. prop 미지정이면 렌더 트리·액션·문구 무변경 |
+| 5 | `packages/store-ui-core/src/index.ts` | `SupplyCatalogCartProducer` 타입 export |
+| 6 | `services/web-glycopharm/src/utils/supplyCatalogCart.ts` (신규) | 카탈로그 행 → canonical cart payload 조립 |
+| 7 | `services/web-glycopharm/.../PharmacyB2BProducts.tsx` | `cart` prop 배선 (`storeCartApi.addItem('glycopharm', …)`, `/store-hub/cart`) |
+| 8 | `packages/store-ui-core/.../__tests__/SupplyCatalogHub.cart-producer.test.tsx` (신규) | opt-in 계약 5건 |
+| 9 | `services/web-glycopharm/src/utils/__tests__/supplyCatalogCart.test.ts` (신규) | payload 계약 8건 |
+| 10 | `services/web-glycopharm/vitest.config.mjs` (신규) · `packages/store-ui-core/vitest.config.mjs` | 실행 경로 확보 (후자는 node → jsdom) |
+| 11 | `.github/workflows/ci-pipeline.yml` | 위 두 suite 를 Code Quality Check 에 blocking 연결 |
+| 12 | `docs/baseline/O4O-B2B-SUPPLIER-TO-STORE-ORDER-CONTRACT-V1.md` | §13-2 불변식 C6(표기 축) · §13-6 cart producer 계약 신설 · DF-5 종결 · DF-7/DF-8 등재 |
+
+**새로 만들지 않은 것:** 소비자 storefront/cart/checkout/payment, 매장 seller order, POS,
+새 cart/order entity, 새 payment flow, `checkout_orders` schema 변경, `/store/b2b-order` 복구.
+
+### 3-1. 담기 payload 계약
+
+```
+sourceType             = 'b2b'
+supplierProductOfferId = 카탈로그 행 id (= supplier_product_offers.id)
+supplierId             = neture_suppliers.id              // 힌트. 서버가 재조회로 확정
+productName            = 표시명
+quantity               = 1                                // 수량 변경은 장바구니에서
+pricingSource          = 'regular'
+priceSnapshot          = priceGold ?? priceGeneral ?? 0   // 표시용. 서버가 재확정
+organizationId         = (보내지 않음)                     // 매장 판정 권위는 서버
+```
+
+금지 사항 준수(§12): 표시명/manufacturer 를 공급자 식별자로 쓰지 않음, sku·barcode heuristic 없음,
+frontend 가격을 권위로 쓰지 않음, legacy `glycopharm_products` id 미사용.
+
+### 3-2. 기존 서비스 회귀 0 (§41)
+
+`SupplyCatalogHub` 의 담기 UI 는 `cart` prop 이 있을 때만 존재한다 — 컬럼 자체가 조건부이고
+ActionBar 액션도 조건부다. KPA-Society · K-Cosmetics 는 prop 을 주지 않으므로 화면이 종전과 동일하다.
+"내 매장/약국에 추가"(ProductApproval PENDING) 액션은 그대로 남는다 — **담기 ≠ 신청 ≠ 주문**.
+
+---
+
+## 4. 검증 실측
+
+| 검증 | 명령 | 결과 |
+|---|---|---|
+| api-server Jest 전체 | `cd apps/api-server && npx jest --maxWorkers=1` | **219 suites / 3689 tests 전부 통과** |
+| cart 축 집중 | `npx jest src/services/cart --maxWorkers=1` | 5 suites / 94 tests 통과 |
+| store-ui-core Vitest | `npx vitest run --config packages/store-ui-core/vitest.config.mjs` | 2 files / 23 tests 통과 |
+| web-glycopharm Vitest | `npx vitest run --config services/web-glycopharm/vitest.config.mjs` | 1 file / 8 tests 통과 |
+| lint ratchet | `node scripts/lint-ratchet.mjs` | 65 errors (baseline 65) · exit 0 |
+| unsafe routes | `node scripts/check-unsafe-routes.mjs` | 1393 파일 · 위반 0 |
+| typeorm entities | `node scripts/check-typeorm-entities.mjs` | 통과 (미등록 0 / 중복 0 / stale 0) |
+| store-ui-core 타입 | `tsc --noEmit` | 오류 0 |
+| web-glycopharm 타입 | `tsc -b` | 본 WO 변경 파일 오류 0 (기존 무관 오류 3건은 그대로 — `OperatorLayoutWrapper.tsx` · `operatorMenuGroups.ts`) |
+
+### 4-1. 프로덕션 실측 (§43 · §44)
+
+**`NO_PRODUCTION_DB_CENSUS`.** 안전한 프로덕션 자격증명이 제공되지 않았으므로 프로덕션 DB 조회를
+수행하지 않았다. 승인 offer 의 실제 건수를 추측하지 않는다. 실제 주문 write 도 하지 않았다
+(안전한 테스트 fixture 없음). 승인 offer 가 0건으로 확인되더라도 approval gate 를 우회하지 않는다.
+
+---
+
+## 5. WO 판정
+
+| § | 요구 | 판정 |
+|---|---|---|
+| 7 | 화면/축 전수조사 | **DONE** — `UNKNOWN = 0` · `UNJUDGED = 0` (§1) |
+| 8 | `glycopharm_products` 를 주문 source 로 쓰지 않음 | **DONE** |
+| 9 | 승인 offer 0건이어도 gate 미완화 | **DONE** — 정합 수정만, 완화 없음 (§2-1) |
+| 10 | frontend 임의 판단 없음 | **DONE** — 자격 판정은 confirm 시 서버 |
+| 12 | 식별자/가격 금지 사항 | **DONE** (§3-1, 테스트 8건) |
+| 13 | cart snapshot 을 최종 가격으로 신뢰하지 않음 | **DONE** — Core 가 재확정 |
+| 14 | 다중 조직 시 임의 선택 금지 | **DONE** — fail closed, DF-7 등재 |
+| 18 | b2b 항목 → `checkout-confirm-b2b` | **DONE** — 기존 `useStoreCart` 그대로 (무변경) |
+| 19 | canonical B2B confirm 연결 | **DONE** — §2-1 수정으로 실제 동작 |
+| 25 | 실패 시 fail closed | **DONE** |
+| 30 · 32 | 은퇴 축 보존 | **DONE** (§1-4) |
+| 34 | serviceKey 우회 불가 | **DONE** — `resolveScope` 멤버십 검사 |
+| 35–41 | 테스트 | **DONE** — backend 회귀 2 + 프론트 계약 13, 전부 CI blocking |
+| 43 · 44 | 프로덕션 실측 | **NO_PRODUCTION_DB_CENSUS** (§4-1) |
+| 45 | baseline 갱신 | **DONE** |
+| 46 | CHECK 작성 | 본 문서 |
+| 47 | 중지 조건 | 해당 없음 — 다른 세션과 파일 충돌 없음, confirm 경로는 main 에 이미 배선돼 있었음 |
+| 48 | commit · push · CI | §6 |
+
+`UNKNOWN = 0` · `UNJUDGED = 0`.
+
+---
+
+## 6. 실행 기록
+
+- 작업 격리 worktree: `C:/tmp/o4o-b2b-buyer-order-read` (branch `work/b2b-confirm-service-agnostic-v1`, base `origin/main` `063e811a5`)
+- Safe Commit 계약 준수: 명시 경로 `git add` → `node scripts/git/check-staged-scope.mjs` → 경로 스코프 commit. `git add .` 미사용, 타 세션 파일 미조작.
+- commit / push / CI 결과는 아래에 추가한다.
+
+## 7. DEFERRED
+
+| # | 내용 | 등재 |
+|---|---|---|
+| DF-7 | 다중 매장 조직 선택 UI | baseline §10 |
+| DF-8 | 승인축 PRIVATE 판정 축(buyerId vs organizationId) 정렬 | baseline §10 |
+| DF-3 | KPA 관심상품 작업대 → canonical 장바구니 (본 WO 범위 밖 유지) | baseline §10 |

--- a/packages/store-ui-core/src/components/supply-catalog/SupplyCatalogHub.tsx
+++ b/packages/store-ui-core/src/components/supply-catalog/SupplyCatalogHub.tsx
@@ -14,7 +14,15 @@
  *
  * 의미 보존:
  *   - "내 매장에 추가" = 공급 상품 신청 (`api.applyBySupplyProductId` → ProductApproval(PENDING)).
- *     신청 ≠ 주문. 주문/장바구니/발주 버튼 미혼입.
+ *     신청 ≠ 주문. 신청 버튼은 어떤 경우에도 주문을 만들지 않는다.
+ *
+ * WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1:
+ *   `cart` prop 이 주어진 서비스에 한해 **opt-in** 으로 canonical B2B 장바구니 producer
+ *   (행 단위 · 선택 일괄)를 추가한다. prop 미지정이면 렌더 트리·액션·문구가 종전과 완전히 동일하므로
+ *   KPA-Society / K-Cosmetics 화면은 영향을 받지 않는다.
+ *   담기는 `store_cart_items` 에 담을 뿐이며 주문이 아니다 — 주문 확정은 장바구니의
+ *   `checkout-confirm-b2b` 축이고, 가격/노출/수량 권위는 전부 서버 재검증이다.
+ *   이 화면은 자격(승인·유통·조직)을 스스로 판단하지 않는다.
  *   - 유통유형 탭 PRIVATE = "공급 승인 대상" (구 '판매자 모집' 은 Neture 파트너 모집과 혼동되어 정정됨,
  *     WO-O4O-SELLER-RECRUITMENT-TERMINOLOGY-BOUNDARY-FIX-V1). 되돌리지 않는다.
  * WO-O4O-STORE-HUB-COMMON-VIEW-AND-SHELL-UNIFICATION-V1:
@@ -26,7 +34,7 @@
  */
 
 import { useState, useCallback, useMemo } from 'react';
-import { Plus, Check, Trash2, X, Loader2 } from 'lucide-react';
+import { Plus, Check, Trash2, X, Loader2, ShoppingCart } from 'lucide-react';
 import { ActionBar } from '@o4o/ui';
 import { DataTable, Pagination } from '@o4o/operator-ux-core';
 import type { ListColumnDef } from '@o4o/operator-ux-core';
@@ -81,6 +89,21 @@ export interface SupplyCatalogHubLabels {
   showSupplierLogo?: boolean;
 }
 
+/**
+ * canonical B2B 장바구니 producer (opt-in).
+ *
+ * 이 계약은 카탈로그 행 → `store_cart_items` 한 방향만 담당한다. 주문 생성·가격 확정·
+ * 승인 판정은 전부 서버(`checkout-confirm-b2b`)의 몫이며 여기서 흉내 내지 않는다.
+ */
+export interface SupplyCatalogCartProducer<T extends SupplyCatalogProduct> {
+  /** 한 행을 장바구니에 담는다(수량 1). 실패 시 throw — 화면은 사유를 그대로 보여준다. */
+  addToCart(product: T): Promise<void>;
+  /** 담은 뒤 안내에 노출할 장바구니 경로. */
+  cartHref: string;
+  /** 버튼/안내 문구. 기본 '장바구니'. */
+  label?: string;
+}
+
 export interface SupplyCatalogHubProps<T extends SupplyCatalogProduct> {
   api: SupplyCatalogApi<T>;
   accent: SupplyCatalogAccent;
@@ -95,6 +118,11 @@ export interface SupplyCatalogHubProps<T extends SupplyCatalogProduct> {
   additionalColumns?: ListColumnDef<T>[];
   /** 공급가 아래 보조 라벨 (KPA '서비스가' / '일반가'). null 이면 미표시. */
   renderPriceSublabel?: (item: T) => string | null;
+  /**
+   * canonical B2B 장바구니 producer. **지정한 서비스에서만** 담기 UI 가 나타난다.
+   * 미지정(기본)이면 이 컴포넌트의 동작은 종전과 동일하다.
+   */
+  cart?: SupplyCatalogCartProducer<T>;
 }
 
 // ─── 탭 (유통유형 — KPA canonical 정합) ───────────────────────────────────────
@@ -166,6 +194,7 @@ export function SupplyCatalogHub<T extends SupplyCatalogProduct>({
   heading,
   additionalColumns,
   renderPriceSublabel,
+  cart,
 }: SupplyCatalogHubProps<T>) {
   const ac = ACCENT_CLASSES[accent];
   const supplierLabel = labels?.supplierLabel ?? '공급자';
@@ -181,6 +210,13 @@ export function SupplyCatalogHub<T extends SupplyCatalogProduct>({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   /** 제외 확인 대상 — window.confirm 대신 인라인 다이얼로그(3 서비스 공통). */
   const [removeConfirmId, setRemoveConfirmId] = useState<string | null>(null);
+
+  // ─── 장바구니 producer 상태 (cart prop 이 있을 때만 의미가 있다) ──────────────
+  const cartLabel = cart?.label ?? '장바구니';
+  const [cartAddingId, setCartAddingId] = useState<string | null>(null);
+  const [cartBulkAdding, setCartBulkAdding] = useState(false);
+  const [cartAddedCount, setCartAddedCount] = useState(0);
+  const [cartError, setCartError] = useState<string | null>(null);
 
   // WO-O4O-STORE-HUB-SUPPLY-PRODUCT-EXPLORER-COMMONIZATION-V1:
   //   목록 조회 · 페이지네이션 · 탭 · loading/empty/error 상태를 공통 Core(useSupplyProductList)로 위임.
@@ -244,6 +280,48 @@ export function SupplyCatalogHub<T extends SupplyCatalogProduct>({
     const { successCount } = await application.bulkApply(targets, { allAlreadyAdded });
     if (successCount > 0 || targets.length > 0) setSelectedIds(new Set());
   }, [application, products, selectedIds]);
+
+  // ─── 장바구니 담기 (opt-in) ───────────────────────────────────────────────
+  //   담기 = 주문 준비. 승인/유통/조직 자격은 확정 시 서버가 판정하므로 여기서 선차단하지 않는다.
+  const handleAddToCart = useCallback(
+    async (product: T) => {
+      if (!cart || cartAddingId || cartBulkAdding) return;
+      setCartAddingId(product.id);
+      setCartError(null);
+      try {
+        await cart.addToCart(product);
+        setCartAddedCount(c => c + 1);
+      } catch (e) {
+        setCartError((e as { message?: string })?.message || '장바구니에 담지 못했습니다.');
+      } finally {
+        setCartAddingId(null);
+      }
+    },
+    [cart, cartAddingId, cartBulkAdding],
+  );
+
+  const handleBulkAddToCart = useCallback(async () => {
+    if (!cart || cartBulkAdding) return;
+    const targets = products.filter(p => selectedIds.has(p.id));
+    if (targets.length === 0) return;
+    setCartBulkAdding(true);
+    setCartError(null);
+    let ok = 0;
+    const failed: string[] = [];
+    // 한 건 실패가 나머지를 막지 않는다. 실패 사유는 서버 문구를 그대로 보여준다.
+    for (const t of targets) {
+      try {
+        await cart.addToCart(t);
+        ok += 1;
+      } catch (e) {
+        failed.push(`${t.name}: ${(e as { message?: string })?.message || '담기 실패'}`);
+      }
+    }
+    setCartAddedCount(c => c + ok);
+    setCartError(failed.length > 0 ? failed.join(' / ') : null);
+    setCartBulkAdding(false);
+    if (ok > 0) setSelectedIds(new Set());
+  }, [cart, cartBulkAdding, products, selectedIds]);
 
   const notAddedSelectedCount = useMemo(
     () => [...selectedIds].filter(k => !products.find(p => p.id === k)?.isAdded).length,
@@ -311,6 +389,32 @@ export function SupplyCatalogHub<T extends SupplyCatalogProduct>({
       },
     },
     ...(additionalColumns ?? []),
+    // 장바구니 컬럼 — cart prop 이 있을 때만 존재한다(다른 서비스는 컬럼 자체가 없다).
+    ...(cart
+      ? [{
+          key: '_cart',
+          header: cartLabel,
+          system: true,
+          align: 'center' as const,
+          width: '90px',
+          onCellClick: () => {},
+          render: (_v: unknown, row: T) => (
+            <div className="flex items-center justify-center">
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); handleAddToCart(row); }}
+                disabled={cartAddingId === row.id || cartBulkAdding}
+                title={`${cartLabel}에 담기`}
+                className={`inline-flex items-center justify-center w-7 h-7 rounded-full disabled:opacity-60 ${ac.applyBtn}`}
+              >
+                {cartAddingId === row.id
+                  ? <Loader2 className="w-4 h-4 animate-spin" />
+                  : <ShoppingCart className="w-4 h-4" />}
+              </button>
+            </div>
+          ),
+        } as ListColumnDef<T>]
+      : []),
     {
       key: '_actions',
       header: '액션',
@@ -357,7 +461,7 @@ export function SupplyCatalogHub<T extends SupplyCatalogProduct>({
         );
       },
     },
-  ], [applyingId, removingId, ac, supplierLabel, storeNoun, showSupplierLogo, additionalColumns, renderPriceSublabel]); // eslint-disable-line react-hooks/exhaustive-deps
+  ], [applyingId, removingId, ac, supplierLabel, storeNoun, showSupplierLogo, additionalColumns, renderPriceSublabel, cart, cartLabel, cartAddingId, cartBulkAdding, handleAddToCart]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const totalPages = list.totalPages;
   const currentPage = list.page;
@@ -435,6 +539,23 @@ export function SupplyCatalogHub<T extends SupplyCatalogProduct>({
         </div>
       ) : (
         <>
+          {/* 장바구니 담기 결과 — 담기 ≠ 주문. 확정은 장바구니에서 한다. */}
+          {cart && cartAddedCount > 0 && (
+            <div className="mb-3 flex items-start gap-2 px-4 py-3 rounded-lg border border-slate-200 bg-slate-50 text-sm text-slate-600">
+              <span className="shrink-0">🛒</span>
+              <span>
+                {cartLabel}에 <strong>{cartAddedCount}건</strong> 담았습니다. 담기는 주문이 아니며,
+                수량 변경과 주문 확정은 장바구니에서 합니다.{' '}
+                <a href={cart.cartHref} className={ac.linkBold}>{cartLabel}로 이동 →</a>
+              </span>
+            </div>
+          )}
+          {cart && cartError && (
+            <div className="mb-3 px-4 py-3 rounded-lg border border-red-200 bg-red-50 text-sm text-red-600">
+              {cartError}
+            </div>
+          )}
+
           {/* ActionBar — 선택 항목 있을 때만 */}
           <div className="mb-3">
             <ActionBar
@@ -457,6 +578,19 @@ export function SupplyCatalogHub<T extends SupplyCatalogProduct>({
                   tooltip: `선택한 상품을 ${storeNoun}에 일괄 추가합니다`,
                   visible: selectedIds.size > 0,
                 },
+                ...(cart
+                  ? [{
+                      key: 'bulk-cart',
+                      label: `${cartLabel}에 담기 (${selectedIds.size})`,
+                      onClick: handleBulkAddToCart,
+                      variant: 'default' as const,
+                      icon: <ShoppingCart className="w-3.5 h-3.5" />,
+                      loading: cartBulkAdding,
+                      group: 'actions',
+                      tooltip: `선택한 상품을 ${cartLabel}에 담습니다 (주문 확정은 장바구니에서)`,
+                      visible: selectedIds.size > 0,
+                    }]
+                  : []),
                 {
                   key: 'clear',
                   label: '선택 해제',

--- a/packages/store-ui-core/src/components/supply-catalog/__tests__/SupplyCatalogHub.cart-producer.test.tsx
+++ b/packages/store-ui-core/src/components/supply-catalog/__tests__/SupplyCatalogHub.cart-producer.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * SupplyCatalogHub — canonical B2B 장바구니 producer (opt-in) 계약
+ *
+ * WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1 (§10 · §38 · §41)
+ *
+ * 고정하는 것
+ *   1. `cart` prop 이 없으면 화면은 종전과 완전히 동일하다 — KPA-Society / K-Cosmetics 회귀 0.
+ *   2. `cart` prop 이 있으면 카탈로그 행을 그대로 producer 에 넘긴다.
+ *   3. 담기는 신청(ProductApproval)과 다른 액션이다 — 담기 버튼이 신청 API 를 부르지 않는다.
+ *   4. 실패는 서버 사유를 그대로 보여주고, frontend 가 자격을 임의 판단하지 않는다.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import { SupplyCatalogHub } from '../SupplyCatalogHub';
+import type { SupplyCatalogProduct } from '../SupplyCatalogHub';
+
+interface Row extends SupplyCatalogProduct {
+  id: string;
+  name: string;
+}
+
+const rows: Row[] = [
+  { id: 'offer-1', name: '상품 A', supplierName: '공급자 A', priceGeneral: 10000, isAdded: false },
+  { id: 'offer-2', name: '상품 B', supplierName: '공급자 B', priceGeneral: 20000, isAdded: false },
+];
+
+function makeApi() {
+  return {
+    getCatalog: vi.fn(async () => ({
+      data: rows,
+      pagination: { total: rows.length, limit: 20, offset: 0 },
+    })),
+    applyBySupplyProductId: vi.fn(async () => ({})),
+    cancelProductByOfferId: vi.fn(async () => ({})),
+  };
+}
+
+const baseProps = { accent: 'teal' as const, tableId: 'test-catalog' };
+
+const cartButtons = () => screen.queryAllByTitle('장바구니에 담기');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('cart prop 미지정 — 기존 서비스 회귀 0 (§41)', () => {
+  it('장바구니 컬럼도 버튼도 렌더하지 않는다', async () => {
+    const api = makeApi();
+    render(<SupplyCatalogHub<Row> {...baseProps} api={api} />);
+
+    await waitFor(() => expect(screen.getByText('상품 A')).toBeTruthy());
+    expect(cartButtons()).toHaveLength(0);
+    expect(screen.queryByText('장바구니')).toBeNull();
+  });
+});
+
+describe('cart prop 지정 — canonical producer (§10 · §38)', () => {
+  it('행 담기는 그 행을 그대로 producer 에 넘긴다', async () => {
+    const api = makeApi();
+    const addToCart = vi.fn(async () => {});
+    render(
+      <SupplyCatalogHub<Row> {...baseProps} api={api} cart={{ addToCart, cartHref: '/store-hub/cart' }} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('상품 A')).toBeTruthy());
+    expect(cartButtons()).toHaveLength(2);
+
+    fireEvent.click(cartButtons()[0]);
+    await waitFor(() => expect(addToCart).toHaveBeenCalledTimes(1));
+    expect(addToCart).toHaveBeenCalledWith(rows[0]);
+  });
+
+  it('담기는 공급 상품 신청(ProductApproval)을 호출하지 않는다 — 담기 ≠ 신청 ≠ 주문', async () => {
+    const api = makeApi();
+    const addToCart = vi.fn(async () => {});
+    render(
+      <SupplyCatalogHub<Row> {...baseProps} api={api} cart={{ addToCart, cartHref: '/store-hub/cart' }} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('상품 A')).toBeTruthy());
+    fireEvent.click(cartButtons()[1]);
+
+    await waitFor(() => expect(addToCart).toHaveBeenCalledWith(rows[1]));
+    expect(api.applyBySupplyProductId).not.toHaveBeenCalled();
+    expect(api.cancelProductByOfferId).not.toHaveBeenCalled();
+  });
+
+  it('성공하면 장바구니로 이동할 수 있는 안내를 보여준다 (확정은 장바구니에서)', async () => {
+    const api = makeApi();
+    const addToCart = vi.fn(async () => {});
+    render(
+      <SupplyCatalogHub<Row> {...baseProps} api={api} cart={{ addToCart, cartHref: '/store-hub/cart' }} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('상품 A')).toBeTruthy());
+    fireEvent.click(cartButtons()[0]);
+
+    const link = await screen.findByText('장바구니로 이동 →');
+    expect(link.getAttribute('href')).toBe('/store-hub/cart');
+  });
+
+  it('실패 사유는 서버 문구를 그대로 보여준다 — frontend 가 자격을 판단하지 않는다', async () => {
+    const api = makeApi();
+    const addToCart = vi.fn(async () => {
+      throw new Error('선택한 매장에 대한 권한이 없습니다.');
+    });
+    render(
+      <SupplyCatalogHub<Row> {...baseProps} api={api} cart={{ addToCart, cartHref: '/store-hub/cart' }} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('상품 A')).toBeTruthy());
+    fireEvent.click(cartButtons()[0]);
+
+    expect(await screen.findByText('선택한 매장에 대한 권한이 없습니다.')).toBeTruthy();
+  });
+});

--- a/packages/store-ui-core/src/index.ts
+++ b/packages/store-ui-core/src/index.ts
@@ -233,6 +233,8 @@ export type {
   SupplyCatalogGetParams,
   SupplyCatalogListResponse,
   SupplyCatalogAccent,
+  // WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1: opt-in 장바구니 producer 계약
+  SupplyCatalogCartProducer,
 } from './components/supply-catalog/SupplyCatalogHub';
 
 // 공급 상품 탐색 공통 Core (WO-O4O-STORE-HUB-SUPPLY-PRODUCT-EXPLORER-COMMONIZATION-V1)

--- a/packages/store-ui-core/vitest.config.mjs
+++ b/packages/store-ui-core/vitest.config.mjs
@@ -10,7 +10,11 @@
  * 실행: 저장소 루트에서
  *   npx vitest run --config packages/store-ui-core/vitest.config.mjs
  *
- * 루트에 이미 설치된 vitest 를 그대로 쓴다.
+ * WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1:
+ *   공급 카탈로그에 opt-in 장바구니 producer 가 붙으면서 컴포넌트 렌더 테스트가 생겼다.
+ *   environment 를 node → jsdom 으로 올린다 (기존 정적 계약 테스트는 그대로 통과한다).
+ *
+ * 루트에 이미 설치된 vitest / jsdom / @testing-library/react 를 그대로 쓴다.
  * 이 패키지에 테스트용 의존성을 추가하지 않는다(package.json · lockfile 무변경).
  * `packages/operator-core-ui/vitest.config.mjs` 와 동일한 방식이다.
  */
@@ -19,7 +23,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   esbuild: { jsx: 'automatic' },
   test: {
-    environment: 'node',
+    environment: 'jsdom',
     include: ['packages/store-ui-core/src/**/*.test.{ts,tsx}'],
     passWithNoTests: false,
   },

--- a/services/web-glycopharm/src/pages/store-management/PharmacyB2BProducts.tsx
+++ b/services/web-glycopharm/src/pages/store-management/PharmacyB2BProducts.tsx
@@ -13,6 +13,17 @@
  *   동일 API/컴포넌트를 재사용하되 헤더 문구와 tableId 만 내 약국 맥락으로 분리한다.
  *
  *   "내 약국에 추가" = 공급 상품 신청(ProductApproval PENDING). 신청 ≠ 주문.
+ *
+ * WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1:
+ *   이 화면에 canonical B2B 장바구니 producer 를 연결한다. 새 주문 UI 를 만드는 것이 아니라
+ *   이미 있는 공급 카탈로그를 이미 완성된 cart/confirm/order 축의 producer 로 잇는 것이다.
+ *
+ *     승인된 supplier_product_offers → store_cart_items(b2b)
+ *       → /store-hub/cart → checkout-confirm-b2b → checkout_orders
+ *
+ *   담기 ≠ 신청 ≠ 주문. 담기는 주문을 만들지 않으며, 자격(승인·유통·조직)과 가격 권위는
+ *   전부 서버에 있다. legacy `/store/b2b-order` 와 `glycopharm_products` 주문 경로는
+ *   되살리지 않는다(은퇴 유지).
  *   레거시 약국 자체 상품(glycopharm_products / pharmacyApi.getProducts)은 admin·operator·
  *   storefront·파트너 모집이 계속 소비하므로 본 전환에서 제거하지 않는다.
  *   (WO-O4O-GLYCOPHARM-LEGACY-B2B-ORDER-PAGE-RETIREMENT-V1: b2b-order 는 소비처에서 빠졌다 —
@@ -26,6 +37,12 @@ import {
   cancelProductByOfferId,
   type CatalogProduct,
 } from '../../api/pharmacyProducts';
+import { storeCartApi } from '../../api/storeCart';
+import { CART_SERVICE_KEY } from '../../utils/eventOfferCart';
+import { buildSupplyCatalogCartPayload } from '../../utils/supplyCatalogCart';
+
+/** 장바구니 화면 경로 (App.tsx 라우트와 동일). */
+const STORE_CART_PATH = '/store-hub/cart';
 
 export default function PharmacyB2BProducts() {
   return (
@@ -38,6 +55,12 @@ export default function PharmacyB2BProducts() {
         description: '약국에서 거래할 공급자 상품을 확인하고 내 약국에 추가할 수 있습니다.',
       }}
       api={{ getCatalog, applyBySupplyProductId, cancelProductByOfferId }}
+      cart={{
+        cartHref: STORE_CART_PATH,
+        addToCart: async (product) => {
+          await storeCartApi.addItem(CART_SERVICE_KEY, buildSupplyCatalogCartPayload(product));
+        },
+      }}
     />
   );
 }

--- a/services/web-glycopharm/src/utils/__tests__/supplyCatalogCart.test.ts
+++ b/services/web-glycopharm/src/utils/__tests__/supplyCatalogCart.test.ts
@@ -1,0 +1,84 @@
+/**
+ * buildSupplyCatalogCartPayload — 승인 공급 카탈로그 → canonical store_cart_items 계약
+ *
+ * WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1 (§12 · §13 · §14 · §38)
+ *
+ * 여기서 고정하는 것은 "무엇을 주문 축으로 넘기는가" 다.
+ *   · offer id 축   — 카탈로그 행 id 는 supplier_product_offers.id 다. master/legacy id 아님.
+ *   · supplier 축    — neture_suppliers.id. 표시명(supplierName)·manufacturer 문자열 아님.
+ *   · 가격 권위      — priceSnapshot 은 표시용. 서버가 확정 시 재확정한다.
+ *   · 조직 권위      — organizationId 를 클라이언트가 정하지 않는다.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildSupplyCatalogCartPayload } from '../supplyCatalogCart';
+import type { CatalogProduct } from '../../api/pharmacyProducts';
+
+const product = (over: Partial<CatalogProduct> = {}): CatalogProduct =>
+  ({
+    id: 'offer-1',
+    name: '상품 A',
+    category: null,
+    description: null,
+    purpose: null,
+    distributionType: 'SERVICE',
+    priceGeneral: 10000,
+    priceGold: 9000,
+    consumerReferencePrice: 12000,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    supplierId: 'sup-1',
+    supplierName: '공급자 A',
+    supplierLogoUrl: null,
+    supplierCategory: null,
+    isAdded: false,
+    ...over,
+  }) as CatalogProduct;
+
+describe('canonical B2B cart payload (§12)', () => {
+  it('카탈로그 행 id 를 supplierProductOfferId 로 넘긴다', () => {
+    const p = buildSupplyCatalogCartPayload(product());
+    expect(p.supplierProductOfferId).toBe('offer-1');
+    expect(p.sourceType).toBe('b2b');
+    expect(p.pricingSource).toBe('regular');
+    expect(p.quantity).toBe(1);
+  });
+
+  it('supplier 축은 supplierId 이며 표시명을 식별자로 쓰지 않는다', () => {
+    const p = buildSupplyCatalogCartPayload(product({ supplierName: '공급자 A' }));
+    expect(p.supplierId).toBe('sup-1');
+    expect(JSON.stringify(p)).not.toContain('공급자 A');
+  });
+
+  it('event_offer / 매장 진열 축을 침범하지 않는다', () => {
+    const p = buildSupplyCatalogCartPayload(product());
+    expect(p.eventOfferId ?? null).toBeNull();
+    expect(p.organizationProductListingId ?? null).toBeNull();
+  });
+
+  it('organizationId 를 클라이언트가 정하지 않는다 — 매장 판정 권위는 서버 (§14)', () => {
+    const p = buildSupplyCatalogCartPayload(product()) as Record<string, unknown>;
+    expect('organizationId' in p).toBe(false);
+  });
+});
+
+describe('가격은 표시용 스냅샷일 뿐이다 (§13)', () => {
+  it('서비스 공급가가 있으면 그것을 표시 스냅샷으로 쓴다', () => {
+    expect(buildSupplyCatalogCartPayload(product()).priceSnapshot).toBe(9000);
+  });
+
+  it('서비스 공급가가 없으면 일반가로 떨어진다', () => {
+    expect(buildSupplyCatalogCartPayload(product({ priceGold: null })).priceSnapshot).toBe(10000);
+  });
+
+  it('가격이 전혀 없어도 담기를 막지 않는다 — 확정 시 서버가 재확정한다', () => {
+    const p = buildSupplyCatalogCartPayload(product({ priceGold: null, priceGeneral: null }));
+    expect(p.priceSnapshot).toBe(0);
+  });
+});
+
+describe('수량 (§24)', () => {
+  it('기본 수량은 1이며, 수량 변경은 장바구니에서 한다', () => {
+    expect(buildSupplyCatalogCartPayload(product()).quantity).toBe(1);
+    expect(buildSupplyCatalogCartPayload(product(), 5).quantity).toBe(5);
+  });
+});

--- a/services/web-glycopharm/src/utils/__tests__/supplyCatalogCart.test.ts
+++ b/services/web-glycopharm/src/utils/__tests__/supplyCatalogCart.test.ts
@@ -56,7 +56,7 @@ describe('canonical B2B cart payload (§12)', () => {
   });
 
   it('organizationId 를 클라이언트가 정하지 않는다 — 매장 판정 권위는 서버 (§14)', () => {
-    const p = buildSupplyCatalogCartPayload(product()) as Record<string, unknown>;
+    const p = buildSupplyCatalogCartPayload(product()) as unknown as Record<string, unknown>;
     expect('organizationId' in p).toBe(false);
   });
 });

--- a/services/web-glycopharm/src/utils/supplyCatalogCart.ts
+++ b/services/web-glycopharm/src/utils/supplyCatalogCart.ts
@@ -1,0 +1,35 @@
+/**
+ * Supply Catalog → Store Cart payload helper (GlycoPharm)
+ *
+ * WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1
+ *
+ * 승인된 공급 카탈로그 행(`supplier_product_offers`)을 canonical `store_cart_items` 의
+ * B2B source 로 담기 위한 payload 만 조립한다.
+ *
+ * 경계:
+ *   · 카탈로그 행의 `id` 는 **SupplierProductOffer id** 다(카탈로그 SSOT 가 `spo.id` 를 반환).
+ *     master_id 나 legacy `glycopharm_products.id` 를 넣지 않는다.
+ *   · `supplierId` 는 `neture_suppliers.id` 이며 표시명(supplierName)·manufacturer 문자열을
+ *     공급자 식별자로 쓰지 않는다.
+ *   · `priceSnapshot` 은 **표시용**이다. 주문 확정 시 서버가
+ *     `offer_service_prices[glycopharm]` → `price_general` 순으로 재확정한다.
+ *   · `organizationId` 는 보내지 않는다 — 매장(조직) 판정 권위는 서버다.
+ */
+import type { AddCartItemInput } from '../api/storeCart';
+import type { CatalogProduct } from '../api/pharmacyProducts';
+
+export function buildSupplyCatalogCartPayload(
+  product: CatalogProduct,
+  quantity = 1,
+): AddCartItemInput {
+  return {
+    sourceType: 'b2b',
+    supplierProductOfferId: product.id,
+    supplierId: product.supplierId ?? null,
+    productName: product.name,
+    quantity,
+    pricingSource: 'regular',
+    // 표시용 스냅샷. 0 이어도 서버가 canonical 가격을 재확정한다.
+    priceSnapshot: product.priceGold ?? product.priceGeneral ?? 0,
+  };
+}

--- a/services/web-glycopharm/vitest.config.mjs
+++ b/services/web-glycopharm/vitest.config.mjs
@@ -1,0 +1,30 @@
+/**
+ * web-glycopharm 테스트 설정
+ *
+ * WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1:
+ *   GlycoPharm 에는 테스트 실행 경로가 없어서 "카탈로그 행 → canonical cart payload" 같은
+ *   계약이 코드 리뷰로만 지켜지고 있었다. 이 축은 잘못되면 조용히 legacy 상품 id 나
+ *   표시용 가격이 주문 경로로 새어 들어가므로 CI 에서 고정한다.
+ *
+ * 실행: 저장소 루트에서
+ *   npx vitest run --config services/web-glycopharm/vitest.config.mjs
+ *
+ * 루트에 이미 설치된 vitest 를 그대로 쓴다 — 이 서비스에 테스트 의존성을 추가하지 않는다
+ * (package.json · lockfile 무변경). `packages/ui/vitest.config.mjs` 와 동일한 방식이다.
+ */
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  esbuild: { jsx: 'automatic' },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    include: ['services/web-glycopharm/src/**/*.test.{ts,tsx}'],
+    passWithNoTests: false,
+  },
+});


### PR DESCRIPTION
WO-O4O-GLYCOPHARM-CANONICAL-B2B-CART-PRODUCER-UI-ADOPTION-V1

`/store/commerce/products` (승인된 supplier_product_offers) → canonical `store_cart_items`
→ service-agnostic B2B checkout confirm → `checkout_orders` 축을 실제로 연결한다.
새 주문 UI를 만드는 것이 아니라, 이미 존재하는 canonical 공급 카탈로그를 이미 완성된
B2B cart/confirm/order 축의 producer 로 연결하는 작업이다. DF-5 종결.

## blocking 결함 수정
`offer-exposure-strategy` 의 승인 축이 `offer_service_approvals.approval_status = 'APPROVED'`
(대문자) 로 비교하고 있었다. 해당 컬럼의 도메인은 **소문자** (`'approved'`) 이므로 EXISTS 가
항상 거짓이 되어 승인축 서비스의 B2B confirm 이 조용히 0건이 되는 상태였다. 완화가 아니라
축 정합 수정이며, 회귀 테스트 2건으로 고정했다.

## 변경
- `store-ui-core` `SupplyCatalogHub` 에 **opt-in** `cart` producer prop 추가 (prop 없으면 KPA/K-Cosmetics 렌더 동일)
- `web-glycopharm` `buildSupplyCatalogCartPayload` — offer id 축 · supplier 축 · 표시용 가격 · `organizationId` 미전송
- `PharmacyB2BProducts` 에서 canonical `storeCartApi.addItem` 연결
- CI: `services/web-glycopharm` vitest blocking step 추가
- baseline §13-2 / 불변식 C6 / §13-6 갱신, CHECK 문서 신규

## 검증
- api-server jest (cart) 5 suites / 94 tests 통과
- store-ui-core vitest 23, web-glycopharm vitest 8 통과
- lint-ratchet 65/65 · unsafe-routes 1393 files / 0 · typeorm-entities 통과
- production DB census 는 안전한 자격증명이 없어 `NO_PRODUCTION_DB_CENSUS` 로 기록

## 보존
`/store/b2b-order` 은퇴 안내 · event_offer 축 격리 · consumer checkout 410 은퇴 모두 유지.
`glycopharm_products` legacy 는 주문 출처가 되지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)